### PR TITLE
Discard non-map items when building includes

### DIFF
--- a/lib/ja_serializer/builder/included.ex
+++ b/lib/ja_serializer/builder/included.ex
@@ -36,6 +36,7 @@ defmodule JaSerializer.Builder.Included do
   end
 
   defp resource_objects_for(structs, conn, serializer, opts) do
+    structs = Enum.filter(structs, &is_map/1)    
     %{data: structs, conn: conn, serializer: serializer, opts: opts}
     |> ResourceObject.build
     |> List.wrap

--- a/test/ja_serializer/builder/included_test.exs
+++ b/test/ja_serializer/builder/included_test.exs
@@ -323,5 +323,6 @@ defmodule JaSerializer.Builder.IncludedTest do
     json = JaSerializer.format(ArticleSerializer, a1, %{}, include: "author")
     keys = Map.keys(json)
     assert not "included" in keys
+    refute is_nil(json["data"]["relationships"]["author"])
   end
 end

--- a/test/ja_serializer/builder/included_test.exs
+++ b/test/ja_serializer/builder/included_test.exs
@@ -316,13 +316,12 @@ defmodule JaSerializer.Builder.IncludedTest do
     assert not "p1" in ids
   end
 
-  test "non-existant include that is serialized into resource identifier results in no includes being added" do
-    c1 = %TestModel.Comment{id: "c1", body: "c1", author: "p1"}
-    a1 = %TestModel.Article{id: "a1", title: "a1", author: "p1", comments: [c1]}
+  test "non-existent include that is serialized into resource identifier results in no includes being added" do
+    a1 = %TestModel.Article{id: "a1", title: "a1", author: "p1"}
     
     json = JaSerializer.format(ArticleSerializer, a1, %{}, include: "author")
     keys = Map.keys(json)
     assert not "included" in keys
-    refute is_nil(json["data"]["relationships"]["author"])
+    assert json["data"]["relationships"]["author"]["data"]["id"] == "p1"
   end
 end

--- a/test/ja_serializer/builder/included_test.exs
+++ b/test/ja_serializer/builder/included_test.exs
@@ -315,4 +315,13 @@ defmodule JaSerializer.Builder.IncludedTest do
     ids = Enum.map(json["included"], &(Map.get(&1, "id")))
     assert not "p1" in ids
   end
+
+  test "non-existant include that is serialized into resource identifier results in no includes being added" do
+    c1 = %TestModel.Comment{id: "c1", body: "c1", author: "p1"}
+    a1 = %TestModel.Article{id: "a1", title: "a1", author: "p1", comments: [c1]}
+    
+    json = JaSerializer.format(ArticleSerializer, a1, %{}, include: "author")
+    keys = Map.keys(json)
+    assert not "included" in keys
+  end
 end


### PR DESCRIPTION
If we want to have the builder create a resource identifier for non-existent includes, we need to provide the ID of the non-existent item when we receive nil in our serialize. But included.ex relies on the relationships being maps. To fix this we filter any non-maps out which prevents them from appearing in the included json object, making the behavior the same as if it were not included at all.