### PR TITLE
small performance updates

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,10 @@
+locals_without_parens = [attributes: 1, location: 1, has_many: 2, has_one: 2]
+
+[
+  inputs: ["*.{ex,exs}", "{bench,lib,test}/**/*.{ex,exs}"],
+  line_length: 80,
+  locals_without_parens: locals_without_parens,
+  export: [
+    locals_without_parens: locals_without_parens
+  ]
+]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,15 @@
 language: elixir
 elixir:
-  - 1.2.0
-  - 1.3.0
-  - 1.4.0
+  - 1.9
+  - 1.10
 otp_release:
-  - 18.0
+  - 22.0
+matrix:
+  include:
+    - elixir: '1.9'
+      script:
+        - mix format --check-formatted
+        - mix test
 after_script:
   - mix deps.get --only docs
   - MIX_ENV=docs mix inch.report

--- a/bench/builder/attribute_bench.exs
+++ b/bench/builder/attribute_bench.exs
@@ -1,7 +1,7 @@
 defmodule Builder.AttributeBench do
   use Benchfella
 
-  @big 1..20 
+  @big 1..20
        |> Enum.map(&{String.to_atom("key_#{&1}"), &1})
        |> Enum.into(%{})
 
@@ -9,45 +9,65 @@ defmodule Builder.AttributeBench do
          |> Enum.map(&{String.to_atom("key_#{&1}"), &1})
          |> Enum.into(%{})
 
-  bench "no opts to process small data",
+  bench(
+    "no opts to process small data",
     [context: data_no_opts(@small)],
     do: JaSerializer.Builder.Attribute.build(context)
+  )
 
-  bench "no opts to process big data",
+  bench(
+    "no opts to process big data",
     [context: data_no_opts(@big)],
     do: JaSerializer.Builder.Attribute.build(context)
+  )
 
-  bench "no field opts to process small data",
+  bench(
+    "no field opts to process small data",
     [context: data_opts(@small)],
     do: JaSerializer.Builder.Attribute.build(context)
+  )
 
-  bench "no field opts to process big data",
+  bench(
+    "no field opts to process big data",
     [context: data_opts(@big)],
     do: JaSerializer.Builder.Attribute.build(context)
+  )
 
-  bench "field opts for wrong serializer small data",
-    [context: data_opts(@small, fields: %{"seabass"=>"fin,scale"})],
+  bench(
+    "field opts for wrong serializer small data",
+    [context: data_opts(@small, fields: %{"seabass" => "fin,scale"})],
     do: JaSerializer.Builder.Attribute.build(context)
+  )
 
-  bench "field opts for wrong serializer big data",
-    [context: data_opts(@big, fields: %{"seabass"=>"fin,scale"})],
+  bench(
+    "field opts for wrong serializer big data",
+    [context: data_opts(@big, fields: %{"seabass" => "fin,scale"})],
     do: JaSerializer.Builder.Attribute.build(context)
+  )
 
-  bench "fields opts for correct serializer small data",
-    [context: data_opts(@small, fields: %{"widget"=>"key_1,key_5"})],
+  bench(
+    "fields opts for correct serializer small data",
+    [context: data_opts(@small, fields: %{"widget" => "key_1,key_5"})],
     do: JaSerializer.Builder.Attribute.build(context)
+  )
 
-  bench "fields opts for correct serializer big data",
-    [context: data_opts(@small, fields: %{"widget"=>"key_1,key_5"})],
+  bench(
+    "fields opts for correct serializer big data",
+    [context: data_opts(@small, fields: %{"widget" => "key_1,key_5"})],
     do: JaSerializer.Builder.Attribute.build(context)
+  )
 
-  bench "optimized opts for correct serializer small data",
-    [context: data_opts(@small, fields: %{"widget"=>[:key_2, :key_8]})],
+  bench(
+    "optimized opts for correct serializer small data",
+    [context: data_opts(@small, fields: %{"widget" => [:key_2, :key_8]})],
     do: JaSerializer.Builder.Attribute.build(context)
+  )
 
-  bench "optimized opts for correct serializer big data",
-    [context: data_opts(@big, fields: %{"widget"=>[:key_2, :key_8]})],
+  bench(
+    "optimized opts for correct serializer big data",
+    [context: data_opts(@big, fields: %{"widget" => [:key_2, :key_8]})],
     do: JaSerializer.Builder.Attribute.build(context)
+  )
 
   defmodule Serializer do
     def type, do: "widget"

--- a/bench/builder/scrivener_links_bench.exs
+++ b/bench/builder/scrivener_links_bench.exs
@@ -1,29 +1,29 @@
 defmodule Builder.ScrivenerLinksBench do
   use Benchfella
 
-  @conn %Plug.Conn{request_path: "/widgets", query_params: %{"oh"=>"my"}}
+  @conn %Plug.Conn{request_path: "/widgets", query_params: %{"oh" => "my"}}
 
-  bench "only one page", [data: data(1,1)] do
+  bench "only one page", data: data(1, 1) do
     JaSerializer.Builder.ScrivenerLinks.build(data)
   end
 
-  bench "page one of two pages", [data: data(1,2)] do
+  bench "page one of two pages", data: data(1, 2) do
     JaSerializer.Builder.ScrivenerLinks.build(data)
   end
 
-  bench "page two of three pages", [data: data(2,3)] do
+  bench "page two of three pages", data: data(2, 3) do
     JaSerializer.Builder.ScrivenerLinks.build(data)
   end
 
-  bench "page two of two pages", [data: data(2,2)] do
+  bench "page two of two pages", data: data(2, 2) do
     JaSerializer.Builder.ScrivenerLinks.build(data)
   end
 
-  bench "page one of three pages", [data: data(1,3)] do
+  bench "page one of three pages", data: data(1, 3) do
     JaSerializer.Builder.ScrivenerLinks.build(data)
   end
 
-  bench "page three of three pages", [data: data(3,3)] do
+  bench "page three of three pages", data: data(3, 3) do
     JaSerializer.Builder.ScrivenerLinks.build(data)
   end
 

--- a/bench/ja_serializer/phoenix_view_bench.exs
+++ b/bench/ja_serializer/phoenix_view_bench.exs
@@ -12,41 +12,69 @@ defmodule JaSerializer.PhoenixViewBench do
   defmodule BenchSmallView do
     use JaSerializer.PhoenixView
 
-    attributes [:key_1,:key_2,:key_3,:key_4,:key_5]
+    attributes [:key_1, :key_2, :key_3, :key_4, :key_5]
   end
 
   defmodule BenchBigView do
     use JaSerializer.PhoenixView
 
-    attributes [:key_1,:key_2,:key_3,:key_4,:key_5,
-                :key_6,:key_7,:key_8,:key_9,:key_10,
-                :key_11,:key_12,:key_13,:key_14,:key_15,
-                :key_16,:key_17,:key_18,:key_19,:key_20]
+    attributes [
+      :key_1,
+      :key_2,
+      :key_3,
+      :key_4,
+      :key_5,
+      :key_6,
+      :key_7,
+      :key_8,
+      :key_9,
+      :key_10,
+      :key_11,
+      :key_12,
+      :key_13,
+      :key_14,
+      :key_15,
+      :key_16,
+      :key_17,
+      :key_18,
+      :key_19,
+      :key_20
+    ]
   end
 
-  bench "attributes map small data",
+  bench(
+    "attributes map small data",
     [context: @small],
     do: BenchSmallView.attributes(context, nil)
+  )
 
-  bench "attributes map big data",
+  bench(
+    "attributes map big data",
     [context: @big],
     do: BenchBigView.attributes(context, nil)
+  )
 
-  bench "render index one item small data",
+  bench(
+    "render index one item small data",
     [context: @small],
     do: BenchSmallView.render("index.json-api", data: context)
+  )
 
-  bench "render index one item map big data",
+  bench(
+    "render index one item map big data",
     [context: @big],
     do: BenchBigView.render("index.json-api", data: context)
+  )
 
-  bench "render index 25 items small data",
-    [context: 1..25 |> Enum.map(fn _ -> @small end) ],
+  bench(
+    "render index 25 items small data",
+    [context: 1..25 |> Enum.map(fn _ -> @small end)],
     do: BenchSmallView.render("index.json-api", data: context)
+  )
 
-  bench "render index 25 items map big data",
+  bench(
+    "render index 25 items map big data",
     [context: 1..25 |> Enum.map(fn _ -> @big end)],
     do: BenchBigView.render("index.json-api", data: context)
-
-
+  )
 end

--- a/lib/ja_serializer.ex
+++ b/lib/ja_serializer.ex
@@ -36,8 +36,9 @@ defmodule JaSerializer do
   defmacro __using__(opts) do
     # Default to using DSL for now.
     opts = Keyword.put_new(opts, :dsl, true)
+
     if opts[:dsl] do
-      quote  do
+      quote do
         use JaSerializer.Serializer
         use JaSerializer.DSL
       end
@@ -58,9 +59,11 @@ defmodule JaSerializer do
     cond do
       data ->
         %{data: data, conn: conn, serializer: serializer, opts: opts}
-        |> JaSerializer.Builder.build
-        |> JaSerializer.Formatter.format
-      is_nil(data) -> %{data: nil}
+        |> JaSerializer.Builder.build()
+        |> JaSerializer.Formatter.format()
+
+      is_nil(data) ->
+        %{data: nil}
     end
   end
 end

--- a/lib/ja_serializer/builder/attribute.ex
+++ b/lib/ja_serializer/builder/attribute.ex
@@ -24,11 +24,14 @@ defmodule JaSerializer.Builder.Attribute do
         attrs
     end
   end
+
   defp filter_fields(attrs, _), do: attrs
 
   defp do_filter(attrs, nil), do: attrs
+
   defp do_filter(attrs, fields) when is_list(fields),
     do: Map.take(attrs, fields)
+
   defp do_filter(attrs, fields) when is_binary(fields),
     do: do_filter(attrs, safe_atom_list(fields))
 

--- a/lib/ja_serializer/builder/attribute.ex
+++ b/lib/ja_serializer/builder/attribute.ex
@@ -17,7 +17,8 @@ defmodule JaSerializer.Builder.Attribute do
   defp filter_fields(attrs, context = %{serializer: serializer, opts: opts}) do
     case Map.get(opts, :fields) do
       fields when is_map(fields) ->
-        do_filter(attrs, fields[serializer.type(context.data, context.conn)])
+        fields = Map.get(fields, serializer.type(context.data, context.conn))
+        do_filter(attrs, fields)
 
       _any ->
         attrs

--- a/lib/ja_serializer/builder/attribute.ex
+++ b/lib/ja_serializer/builder/attribute.ex
@@ -15,9 +15,12 @@ defmodule JaSerializer.Builder.Attribute do
   end
 
   defp filter_fields(attrs, context = %{serializer: serializer, opts: opts}) do
-    case opts[:fields] do
-      fields when is_map(fields) -> do_filter(attrs, fields[serializer.type(context.data, context.conn)])
-      _any -> attrs
+    case Map.get(opts, :fields) do
+      fields when is_map(fields) ->
+        do_filter(attrs, fields[serializer.type(context.data, context.conn)])
+
+      _any ->
+        attrs
     end
   end
   defp filter_fields(attrs, _), do: attrs

--- a/lib/ja_serializer/builder/included.ex
+++ b/lib/ja_serializer/builder/included.ex
@@ -8,14 +8,15 @@ defmodule JaSerializer.Builder.Included do
   end
 
   def build(%{data: data} = context, primary_resources) when is_list(data) do
-    known = primary_resources
-            |> List.wrap
-            |> Enum.map(&resource_key/1)
-            |> Enum.into(MapSet.new)
+    known =
+      primary_resources
+      |> List.wrap()
+      |> Enum.map(&resource_key/1)
+      |> Enum.into(MapSet.new())
 
     data
     |> do_build(context, %{}, known)
-    |> Map.values
+    |> Map.values()
   end
 
   def build(context, primary_resources) do
@@ -25,21 +26,26 @@ defmodule JaSerializer.Builder.Included do
   end
 
   defp do_build([], _context, included, _known_resources), do: included
+
   defp do_build([struct | structs], context, included, known) do
-    context  = Map.put(context, :data, struct)
-    included = context
-                |> relationships_with_include
-                |> Enum.reduce(included, fn rel_definition, included ->
-                  resources_for_relationship(rel_definition, context, included, known)
-                end)
+    context = Map.put(context, :data, struct)
+
+    included =
+      context
+      |> relationships_with_include
+      |> Enum.reduce(included, fn rel_definition, included ->
+        resources_for_relationship(rel_definition, context, included, known)
+      end)
+
     do_build(structs, context, included, known)
   end
 
   defp resource_objects_for(structs, conn, serializer, opts) do
     structs = Enum.filter(structs, &is_map/1)
+
     %{data: structs, conn: conn, serializer: serializer, opts: opts}
-    |> ResourceObject.build
-    |> List.wrap
+    |> ResourceObject.build()
+    |> List.wrap()
   end
 
   # Find relationships that should be included.
@@ -53,7 +59,6 @@ defmodule JaSerializer.Builder.Included do
       case Map.get(context.opts, :include) do
         # if `include` param is not present only return 'default' includes
         nil -> rel_definition.include == true
-
         # otherwise only include requested includes
         includes -> is_list(includes[rel_name])
       end
@@ -92,10 +97,12 @@ defmodule JaSerializer.Builder.Included do
   end
 
   defp get_data(_, %{data: nil}), do: nil
+
   defp get_data(context, %{data: data}) when is_atom(data) do
     context.serializer
     |> apply(data, [context.data, context.conn])
   end
+
   defp get_data(_, %{data: data}), do: data
 
   defp opts_with_includes_for_relation(opts, rel_name) do

--- a/lib/ja_serializer/builder/link.ex
+++ b/lib/ja_serializer/builder/link.ex
@@ -8,7 +8,7 @@ defmodule JaSerializer.Builder.Link do
   def build(context) do
     context.data
     |> context.serializer.links(context.conn)
-    |> Enum.map(fn({type, path}) -> build(context, type, path) end)
+    |> Enum.map(fn {type, path} -> build(context, type, path) end)
   end
 
   def build(_context, _type, nil), do: nil
@@ -29,16 +29,18 @@ defmodule JaSerializer.Builder.Link do
 
   defp path_for_context(context, path) do
     uri = URI.parse(path)
-    path = uri
-    |> Map.put(:path, replaced_path_for_context(context, uri.path))
-    |> Map.put(:query, replaced_path_for_context(context, uri.query))
-    |> URI.to_string
+
+    path =
+      uri
+      |> Map.put(:path, replaced_path_for_context(context, uri.path))
+      |> Map.put(:query, replaced_path_for_context(context, uri.query))
+      |> URI.to_string()
 
     # Remove trailing question mark if there is no query string.
     # A query string itself can contain a trailing question mark so we only
     # do this if URI did not parse out a query.
     if nil == uri.query do
-      Regex.replace ~r/\?$/, path, ""
+      Regex.replace(~r/\?$/, path, "")
     else
       path
     end

--- a/lib/ja_serializer/builder/pagination_links.ex
+++ b/lib/ja_serializer/builder/pagination_links.ex
@@ -1,7 +1,11 @@
 defmodule JaSerializer.Builder.PaginationLinks do
   import JaSerializer.Formatter.Utils, only: [format_key: 1]
 
-  @page_number_origin Application.get_env(:ja_serializer, :page_number_origin, 1)
+  @page_number_origin Application.get_env(
+                        :ja_serializer,
+                        :page_number_origin,
+                        1
+                      )
 
   @moduledoc """
   Builds JSON-API spec pagination links.
@@ -62,20 +66,30 @@ defmodule JaSerializer.Builder.PaginationLinks do
 
   defp links(%{number: @page_number_origin, total: 1}),
     do: [self: @page_number_origin]
+
   defp links(%{number: @page_number_origin, total: 0}),
     do: [self: @page_number_origin]
+
   defp links(%{number: @page_number_origin, total: t}),
     do: [self: @page_number_origin, next: 2, last: t]
+
   defp links(%{number: total, total: total}),
     do: [self: total, first: @page_number_origin, prev: total - 1]
+
   defp links(%{number: number, total: total}),
-    do: [self: number, first: @page_number_origin, prev: number - 1, next: number + 1, last: total]
+    do: [
+      self: number,
+      first: @page_number_origin,
+      prev: number - 1,
+      next: number + 1,
+      last: total
+    ]
 
   defp page_url(number, base, size, orginal_params) do
     params =
       orginal_params
       |> Map.merge(page_params(number, size))
-      |> Plug.Conn.Query.encode
+      |> Plug.Conn.Query.encode()
 
     "#{base}?#{params}"
   end
@@ -102,5 +116,6 @@ defmodule JaSerializer.Builder.PaginationLinks do
   defp base_url(conn, nil) do
     Application.get_env(:ja_serializer, :page_base_url, conn.request_path)
   end
+
   defp base_url(_conn, url), do: url
 end

--- a/lib/ja_serializer/builder/relationship.ex
+++ b/lib/ja_serializer/builder/relationship.ex
@@ -6,15 +6,18 @@ defmodule JaSerializer.Builder.Relationship do
 
   defstruct [:name, :links, :data, :meta]
 
-  def build(%{serializer: serializer, data: data, conn: conn, opts: opts} = context) do
+  def build(
+        %{serializer: serializer, data: data, conn: conn, opts: opts} = context
+      ) do
     case Map.get(opts, :relationships) do
       false -> []
-      _ -> Enum.map serializer.relationships(data, conn), &(build(&1, context))
+      _ -> Enum.map(serializer.relationships(data, conn), &build(&1, context))
     end
   end
 
   def build({name, definition}, context) do
     definition = Map.put(definition, :name, name)
+
     %__MODULE__{name: name}
     |> add_links(definition, context)
     |> add_data(definition, context)
@@ -22,11 +25,11 @@ defmodule JaSerializer.Builder.Relationship do
 
   defp add_links(relation, definition, context) do
     definition.links
-      |> Enum.map(fn {key, path} -> Link.build(context, key, path) end)
-      |> case do
-        []   ->  relation
-        links -> Map.put(relation, :links, links)
-      end
+    |> Enum.map(fn {key, path} -> Link.build(context, key, path) end)
+    |> case do
+      [] -> relation
+      links -> Map.put(relation, :links, links)
+    end
   end
 
   defp add_data(relation, definition, context) do
@@ -39,17 +42,32 @@ defmodule JaSerializer.Builder.Relationship do
 
   defp should_have_identifiers?(%{type: nil, serializer: nil}, _c),
     do: false
+
   defp should_have_identifiers?(%{type: _t, serializer: nil}, _c),
     do: true
+
   defp should_have_identifiers?(%{serializer: _s, identifiers: :always}, _c),
     do: true
-  defp should_have_identifiers?(%{serializer: _s, identifiers: :when_included, name: name, include: true}, context) do
+
+  defp should_have_identifiers?(
+         %{
+           serializer: _s,
+           identifiers: :when_included,
+           name: name,
+           include: true
+         },
+         context
+       ) do
     case Map.get(context.opts, :include) do
       nil -> true
       includes -> is_list(Keyword.get(includes, name))
     end
   end
-  defp should_have_identifiers?(%{serializer: _s, identifiers: :when_included, name: name}, context) do
+
+  defp should_have_identifiers?(
+         %{serializer: _s, identifiers: :when_included, name: name},
+         context
+       ) do
     case Map.get(context.opts, :include) do
       nil -> false
       includes -> is_list(Keyword.get(includes, name))

--- a/lib/ja_serializer/builder/relationship.ex
+++ b/lib/ja_serializer/builder/relationship.ex
@@ -7,7 +7,7 @@ defmodule JaSerializer.Builder.Relationship do
   defstruct [:name, :links, :data, :meta]
 
   def build(%{serializer: serializer, data: data, conn: conn, opts: opts} = context) do
-    case opts[:relationships] do
+    case Map.get(opts, :relationships) do
       false -> []
       _ -> Enum.map serializer.relationships(data, conn), &(build(&1, context))
     end
@@ -44,13 +44,13 @@ defmodule JaSerializer.Builder.Relationship do
   defp should_have_identifiers?(%{serializer: _s, identifiers: :always}, _c),
     do: true
   defp should_have_identifiers?(%{serializer: _s, identifiers: :when_included, name: name, include: true}, context) do
-    case context[:opts][:include] do
+    case Map.get(context.opts, :include) do
       nil  -> true
       includes -> is_list(includes[name])
     end
   end
   defp should_have_identifiers?(%{serializer: _s, identifiers: :when_included, name: name}, context) do
-    case context[:opts][:include] do
+    case Map.get(context.opts, :include) do
       nil  -> false
       includes -> is_list(includes[name])
     end

--- a/lib/ja_serializer/builder/relationship.ex
+++ b/lib/ja_serializer/builder/relationship.ex
@@ -45,14 +45,14 @@ defmodule JaSerializer.Builder.Relationship do
     do: true
   defp should_have_identifiers?(%{serializer: _s, identifiers: :when_included, name: name, include: true}, context) do
     case Map.get(context.opts, :include) do
-      nil  -> true
-      includes -> is_list(includes[name])
+      nil -> true
+      includes -> is_list(Keyword.get(includes, name))
     end
   end
   defp should_have_identifiers?(%{serializer: _s, identifiers: :when_included, name: name}, context) do
     case Map.get(context.opts, :include) do
-      nil  -> false
-      includes -> is_list(includes[name])
+      nil -> false
+      includes -> is_list(Keyword.get(includes, name))
     end
   end
 end

--- a/lib/ja_serializer/builder/resource_identifier.ex
+++ b/lib/ja_serializer/builder/resource_identifier.ex
@@ -5,18 +5,27 @@ defmodule JaSerializer.Builder.ResourceIdentifier do
 
   def build(context, definition) do
     case get_data(context, definition) do
-      [] -> [:empty_relationship]
-      nil -> :empty_relationship
-      many when is_list(many) -> Enum.map(many, &do_build(&1, context, definition))
-      one -> do_build(one, context, definition)
+      [] ->
+        [:empty_relationship]
+
+      nil ->
+        :empty_relationship
+
+      many when is_list(many) ->
+        Enum.map(many, &do_build(&1, context, definition))
+
+      one ->
+        do_build(one, context, definition)
     end
   end
 
   defp get_data(_, %{data: nil}), do: nil
+
   defp get_data(context, %{data: data}) when is_atom(data) do
     context.serializer
     |> apply(data, [context.data, context.conn])
   end
+
   defp get_data(_, %{data: data}), do: data
 
   defp do_build(data, context, definition) do
@@ -29,23 +38,33 @@ defmodule JaSerializer.Builder.ResourceIdentifier do
   defp find_id(%{} = data, _context, %{serializer: nil}) do
     Map.get(data, :id)
   end
+
   defp find_id(%{} = data, context, %{serializer: serializer}) do
     serializer.id(data, context.conn)
   end
+
   defp find_id(id, _, _), do: id
 
   defp find_type(_data, _context, %{type: type, serializer: nil}), do: type
+
   defp find_type(data, context, %{serializer: serializer}) do
     case serializer.type(data, context.conn) do
       type_fun when is_function(type_fun) ->
-        IO.write :stderr, IO.ANSI.format([:red, :bright,
-          "warning: returning an anonymous function from type/0 is " <>
-          "deprecated. Please use the `type/2` callback instead.\n" <>
-          Exception.format_stacktrace()
-        ])
+        IO.write(
+          :stderr,
+          IO.ANSI.format([
+            :red,
+            :bright,
+            "warning: returning an anonymous function from type/0 is " <>
+              "deprecated. Please use the `type/2` callback instead.\n" <>
+              Exception.format_stacktrace()
+          ])
+        )
+
         type_fun.(data, context.conn)
-      type -> type
+
+      type ->
+        type
     end
   end
-
 end

--- a/lib/ja_serializer/builder/resource_object.ex
+++ b/lib/ja_serializer/builder/resource_object.ex
@@ -8,25 +8,27 @@ defmodule JaSerializer.Builder.ResourceObject do
   defstruct [:id, :type, :attributes, :relationships, :links, :meta, :data]
 
   def build(%{data: data} = context) when is_list(data) do
-    Enum.map data, fn(struct) ->
+    Enum.map(data, fn struct ->
       context
       |> Map.put(:data, struct)
       |> build
-    end
+    end)
   end
 
   def build(%{serializer: serializer} = context) do
     %__MODULE__{
-      id:            serializer.id(context.data, context.conn),
-      type:          __type(serializer.type(context.data, context.conn), context),
-      data:          context.data,
-      attributes:    Attribute.build(context),
+      id: serializer.id(context.data, context.conn),
+      type: __type(serializer.type(context.data, context.conn), context),
+      data: context.data,
+      attributes: Attribute.build(context),
       relationships: Relationship.build(context),
-      links:         Link.build(context),
-      meta:          serializer.meta(context.data, context.conn)
+      links: Link.build(context),
+      meta: serializer.meta(context.data, context.conn)
     }
   end
 
-  defp __type(type, context) when is_function(type), do: type.(context.data, context.conn)
+  defp __type(type, context) when is_function(type),
+    do: type.(context.data, context.conn)
+
   defp __type(type, _), do: type
 end

--- a/lib/ja_serializer/builder/top_level.ex
+++ b/lib/ja_serializer/builder/top_level.ex
@@ -12,7 +12,7 @@ defmodule JaSerializer.Builder.TopLevel do
       opts = Enum.into(opts, %{})
       # Build scrivener pagination links before we lose page object
       links = JaSerializer.Builder.ScrivenerLinks.build(context)
-      opts = Map.update(opts, :page, links, &(Map.merge(links, &1)))
+      opts = Map.update(opts, :page, links, &Map.merge(links, &1))
 
       # Extract entries from page object
       build(%{context | data: page.entries, opts: opts})
@@ -34,6 +34,7 @@ defmodule JaSerializer.Builder.TopLevel do
       )
 
     data = ResourceObject.build(context)
+
     %__MODULE__{}
     |> Map.put(:data, data)
     |> add_included(context)
@@ -44,7 +45,7 @@ defmodule JaSerializer.Builder.TopLevel do
   defp add_included(tl, %{opts: opts} = context) do
     case Map.get(opts, :relationships) do
       false -> tl
-      _     -> Map.put(tl, :included, Included.build(context, tl.data))
+      _ -> Map.put(tl, :included, Included.build(context, tl.data))
     end
   end
 
@@ -54,15 +55,17 @@ defmodule JaSerializer.Builder.TopLevel do
   end
 
   defp pagination_links(nil, _), do: []
+
   defp pagination_links(page, context) do
     page
     |> Enum.into(%{})
     |> Map.take([:self, :first, :next, :prev, :last])
-    |> Enum.map(fn({type, url}) -> Link.build(context, type, url) end)
+    |> Enum.map(fn {type, url} -> Link.build(context, type, url) end)
   end
 
   defp normalize_opts(opts) do
     opts = Enum.into(opts, %{})
+
     case Map.get(opts, :include) do
       nil -> opts
       includes -> Map.put(opts, :include, normalize_includes(includes))
@@ -75,27 +78,37 @@ defmodule JaSerializer.Builder.TopLevel do
     |> normalize_relationship_path_list
   end
 
-  defp normalize_relationship_path_list(paths), do:
-    normalize_relationship_path_list(paths, [])
+  defp normalize_relationship_path_list(paths),
+    do: normalize_relationship_path_list(paths, [])
 
   defp normalize_relationship_path_list([], normalized), do: normalized
+
   defp normalize_relationship_path_list([path | paths], normalized) do
-    normalized = path
-    |> String.split(".")
-    |> Enum.map(&JaSerializer.ParamParser.Utils.format_key/1)
-    |> normalize_relationship_path
-    |> deep_merge_relationship_paths(normalized)
+    normalized =
+      path
+      |> String.split(".")
+      |> Enum.map(&JaSerializer.ParamParser.Utils.format_key/1)
+      |> normalize_relationship_path
+      |> deep_merge_relationship_paths(normalized)
 
     normalize_relationship_path_list(paths, normalized)
   end
 
   defp normalize_relationship_path([]), do: []
+
   defp normalize_relationship_path([rel_name | remaining]) do
-    Keyword.put([], String.to_atom(rel_name), normalize_relationship_path(remaining))
+    Keyword.put(
+      [],
+      String.to_atom(rel_name),
+      normalize_relationship_path(remaining)
+    )
   end
 
-  defp deep_merge_relationship_paths(left, right), do: Keyword.merge(left, right, &deep_merge_relationship_paths/3)
-  defp deep_merge_relationship_paths(_key, left, right), do: deep_merge_relationship_paths(left, right)
+  defp deep_merge_relationship_paths(left, right),
+    do: Keyword.merge(left, right, &deep_merge_relationship_paths/3)
+
+  defp deep_merge_relationship_paths(_key, left, right),
+    do: deep_merge_relationship_paths(left, right)
 
   defp add_meta(tl, nil), do: tl
   defp add_meta(tl, %{} = meta), do: Map.put(tl, :meta, meta)

--- a/lib/ja_serializer/content_type_negotiation.ex
+++ b/lib/ja_serializer/content_type_negotiation.ex
@@ -22,41 +22,43 @@ defmodule JaSerializer.ContentTypeNegotiation do
 
   use Plug.Builder
 
-  plug :verify_content_type
-  plug :verify_accepts
-  plug :set_content_type
+  plug(:verify_content_type)
+  plug(:verify_accepts)
+  plug(:set_content_type)
 
   @jsonapi "application/vnd.api+json"
 
   def verify_content_type(%Plug.Conn{method: "HEAD"} = conn, _o), do: conn
   def verify_content_type(%Plug.Conn{method: "GET"} = conn, _o), do: conn
   def verify_content_type(%Plug.Conn{method: "DELETE"} = conn, _o), do: conn
+
   def verify_content_type(%Plug.Conn{} = conn, _o) do
     if Enum.member?(get_req_header(conn, "content-type"), @jsonapi) do
       conn
     else
-      halt send_resp(conn, 415, "")
+      halt(send_resp(conn, 415, ""))
     end
   end
 
   def verify_accepts(conn, _opts) do
-    accepts = conn
-              |> get_req_header("accept")
-              |> Enum.flat_map(&(String.split(&1, ",")))
-              |> Enum.map(&String.strip/1)
+    accepts =
+      conn
+      |> get_req_header("accept")
+      |> Enum.flat_map(&String.split(&1, ","))
+      |> Enum.map(&String.strip/1)
 
     cond do
-      accepts == []                          -> conn
-      Enum.member?(accepts, @jsonapi)        -> conn
+      accepts == [] -> conn
+      Enum.member?(accepts, @jsonapi) -> conn
       Enum.member?(accepts, "application/*") -> conn
-      Enum.member?(accepts, "*/*")           -> conn
-      true                                   -> halt send_resp(conn, 406, "")
+      Enum.member?(accepts, "*/*") -> conn
+      true -> halt(send_resp(conn, 406, ""))
     end
   end
 
   def set_content_type(conn, _opts) do
-    register_before_send conn, fn(later_conn) ->
-      update_resp_header(later_conn, "content-type", @jsonapi, &(&1))
-    end
+    register_before_send(conn, fn later_conn ->
+      update_resp_header(later_conn, "content-type", @jsonapi, & &1)
+    end)
   end
 end

--- a/lib/ja_serializer/deserializer.ex
+++ b/lib/ja_serializer/deserializer.ex
@@ -34,7 +34,8 @@ defmodule JaSerializer.Deserializer do
   @behaviour Plug
 
   def init(opts), do: opts
-  def call(conn, _opts) do 
+
+  def call(conn, _opts) do
     Map.put(conn, :params, JaSerializer.ParamParser.parse(conn.params))
   end
 end

--- a/lib/ja_serializer/ecto_error_serializer.ex
+++ b/lib/ja_serializer/ecto_error_serializer.ex
@@ -32,27 +32,32 @@ defmodule JaSerializer.EctoErrorSerializer do
   def format(errors), do: format(errors, [])
   def format(errors, conn) when is_map(conn), do: format(errors, [])
   def format(%{__struct__: Ecto.Changeset} = cs, o), do: format(cs.errors, o)
+
   def format(errors, opts) do
     errors
-    |> Enum.map(&(format_each(&1, opts[:opts])))
-    |> JaSerializer.ErrorSerializer.format
+    |> Enum.map(&format_each(&1, opts[:opts]))
+    |> JaSerializer.ErrorSerializer.format()
   end
-  def format(%{__struct__: Ecto.Changeset} = cs, _c, o), do: format(cs.errors, o)
+
+  def format(%{__struct__: Ecto.Changeset} = cs, _c, o),
+    do: format(cs.errors, o)
 
   defp format_each({field, {message, vals}}, opts) do
     # See https://github.com/elixir-ecto/ecto/blob/34a1012dd1f6d218c0183deb512b6c084afe3b6f/lib/ecto/changeset.ex#L1836-L1838
-    title = Enum.reduce(vals, message, fn {key, value}, acc ->
-      case key do
-        :type -> acc
-        _ -> String.replace(acc, "%{#{key}}", to_string(value))
-      end
-    end)
+    title =
+      Enum.reduce(vals, message, fn {key, value}, acc ->
+        case key do
+          :type -> acc
+          _ -> String.replace(acc, "%{#{key}}", to_string(value))
+        end
+      end)
 
     %{
       source: %{pointer: pointer_for(field)},
       title: title,
       detail: "#{Utils.humanize(field)} #{title}"
-    } |> merge_opts(opts)
+    }
+    |> merge_opts(opts)
   end
 
   defp format_each({field, message}, opts) do
@@ -60,14 +65,17 @@ defmodule JaSerializer.EctoErrorSerializer do
       source: %{pointer: pointer_for(field)},
       title: message,
       detail: "#{Utils.humanize(field)} #{message}"
-    } |> merge_opts(opts)
+    }
+    |> merge_opts(opts)
   end
 
   defp merge_opts(error, nil), do: error
+
   defp merge_opts(error, opts) when is_list(opts) do
     opts = Enum.into(opts, %{})
     Map.merge(error, opts)
   end
+
   defp merge_opts(error, _opts), do: error
 
   # Assumes relationship name is the same as the field name without the id.
@@ -75,7 +83,7 @@ defmodule JaSerializer.EctoErrorSerializer do
   # ideas this will work for most relationships.
   defp pointer_for(field) do
     case Regex.run(~r/(.*)_id$/, to_string(field)) do
-      nil      -> "/data/attributes/#{Utils.format_key(field)}"
+      nil -> "/data/attributes/#{Utils.format_key(field)}"
       [_, rel] -> "/data/relationships/#{Utils.format_key(rel)}"
     end
   end

--- a/lib/ja_serializer/error_serializer.ex
+++ b/lib/ja_serializer/error_serializer.ex
@@ -14,16 +14,19 @@ defmodule JaSerializer.ErrorSerializer do
 
   def format(error), do: format(error, %{})
   def format(error, conn), do: format(error, conn, [])
+
   def format(errors, _conn, _opts) when is_list(errors) do
     errors = errors |> Enum.map(&format_one/1)
-    %TopLevel{errors: errors} |> Formatter.format
+    %TopLevel{errors: errors} |> Formatter.format()
   end
-  def format(error, _conn, _opts) do
-    errors = error
-    |> format_one
-    |> List.wrap
 
-    %TopLevel{errors: errors} |> Formatter.format
+  def format(error, _conn, _opts) do
+    errors =
+      error
+      |> format_one
+      |> List.wrap()
+
+    %TopLevel{errors: errors} |> Formatter.format()
   end
 
   @error_fields ~w(id links about status code title detail source meta)a

--- a/lib/ja_serializer/formatter.ex
+++ b/lib/ja_serializer/formatter.ex
@@ -13,7 +13,8 @@ defimpl JaSerializer.Formatter, for: List do
 end
 
 # Pass built in data types through
-defimpl JaSerializer.Formatter, for: [BitString, Integer, Float, Atom, Function, PID, Port, Reference, Tuple] do
+defimpl JaSerializer.Formatter,
+  for: [BitString, Integer, Float, Atom, Function, PID, Port, Reference, Tuple] do
   def format(data), do: data
 end
 

--- a/lib/ja_serializer/formatter/relationship.ex
+++ b/lib/ja_serializer/formatter/relationship.ex
@@ -2,9 +2,11 @@ defimpl JaSerializer.Formatter, for: JaSerializer.Builder.Relationship do
   alias JaSerializer.Formatter.Utils
 
   def format(rel) do
-    json = %{}
-    |> Utils.add_data_if_present(JaSerializer.Formatter.format(rel.data))
-    |> Utils.put_if_present("links", Utils.array_to_hash(rel.links))
+    json =
+      %{}
+      |> Utils.add_data_if_present(JaSerializer.Formatter.format(rel.data))
+      |> Utils.put_if_present("links", Utils.array_to_hash(rel.links))
+
     {Utils.format_key(rel.name), json}
   end
 end

--- a/lib/ja_serializer/formatter/resource.ex
+++ b/lib/ja_serializer/formatter/resource.ex
@@ -6,14 +6,17 @@ defimpl JaSerializer.Formatter, for: JaSerializer.Builder.ResourceObject do
     links = Utils.array_to_hash(resource.links)
 
     json = %{
-      "id"         => to_string(resource.id),
-      "type"       => resource.type,
-      "attributes" => Utils.array_to_hash(resource.attributes),
+      "id" => to_string(resource.id),
+      "type" => resource.type,
+      "attributes" => Utils.array_to_hash(resource.attributes)
     }
 
     json
     |> Utils.put_if_present("relationships", relationships)
     |> Utils.put_if_present("links", links)
-    |> Utils.put_if_present("meta", JaSerializer.Formatter.format(resource.meta))
+    |> Utils.put_if_present(
+      "meta",
+      JaSerializer.Formatter.format(resource.meta)
+    )
   end
 end

--- a/lib/ja_serializer/formatter/resource_identifier.ex
+++ b/lib/ja_serializer/formatter/resource_identifier.ex
@@ -1,7 +1,7 @@
 defimpl JaSerializer.Formatter, for: JaSerializer.Builder.ResourceIdentifier do
   def format(resource) do
     %{
-      "id"   => to_string(resource.id),
+      "id" => to_string(resource.id),
       "type" => resource.type
     }
   end

--- a/lib/ja_serializer/formatter/top_level.ex
+++ b/lib/ja_serializer/formatter/top_level.ex
@@ -4,24 +4,30 @@ defimpl JaSerializer.Formatter, for: JaSerializer.Builder.TopLevel do
   @jsonapi_version "1.0"
 
   def format(struct = %{errors: nil}) do
-    %{"data" =>  JaSerializer.Formatter.format(struct.data)}
+    %{"data" => JaSerializer.Formatter.format(struct.data)}
     |> format_links(struct.links)
     |> Utils.put_if_present("meta", JaSerializer.Formatter.format(struct.meta))
-    |> Utils.put_if_present("included", JaSerializer.Formatter.format(struct.included))
+    |> Utils.put_if_present(
+      "included",
+      JaSerializer.Formatter.format(struct.included)
+    )
     |> put_version
   end
 
   def format(struct = %{data: nil}) do
-    %{"errors" =>  JaSerializer.Formatter.format(struct.errors)} |> put_version
+    %{"errors" => JaSerializer.Formatter.format(struct.errors)} |> put_version
   end
 
   defp format_links(resource, nil), do: resource
   defp format_links(resource, []), do: resource
+
   defp format_links(resource, links) do
-    links = links
-            |> JaSerializer.Formatter.format
-            |> Enum.reject(&(is_nil(&1)))
-            |> Enum.into(%{})
+    links =
+      links
+      |> JaSerializer.Formatter.format()
+      |> Enum.reject(&is_nil(&1))
+      |> Enum.into(%{})
+
     Map.put(resource, "links", links)
   end
 

--- a/lib/ja_serializer/formatter/utils.ex
+++ b/lib/ja_serializer/formatter/utils.ex
@@ -3,19 +3,24 @@ defmodule JaSerializer.Formatter.Utils do
 
   @doc false
   def put_if_present(dict, _key, nil), do: dict
-  def put_if_present(dict, _key, []),  do: dict
-  def put_if_present(dict, _key, ""),  do: dict
+  def put_if_present(dict, _key, []), do: dict
+  def put_if_present(dict, _key, ""), do: dict
   def put_if_present(dict, _key, %{} = map) when map_size(map) == 0, do: dict
   def put_if_present(dict, key, val), do: Map.put(dict, key, val)
 
   @doc false
-  def add_data_if_present(dict, :empty_relationship), do: Map.put(dict, "data", nil)
-  def add_data_if_present(dict, [:empty_relationship]), do: Map.put(dict, "data", [])
+  def add_data_if_present(dict, :empty_relationship),
+    do: Map.put(dict, "data", nil)
+
+  def add_data_if_present(dict, [:empty_relationship]),
+    do: Map.put(dict, "data", [])
+
   def add_data_if_present(dict, val), do: put_if_present(dict, "data", val)
 
   @doc false
-  def array_to_hash(nil),   do: nil
+  def array_to_hash(nil), do: nil
   def array_to_hash([nil]), do: nil
+
   def array_to_hash(structs) do
     structs
     |> Enum.map(&JaSerializer.Formatter.format/1)
@@ -28,24 +33,28 @@ defmodule JaSerializer.Formatter.Utils do
   def deep_format_keys(map) when is_map(map) do
     Enum.reduce(map, %{}, &deep_format_key_value/2)
   end
+
   def deep_format_keys(other), do: other
 
   defp deep_format_key_value({key, value}, accumulator) when is_map(value) do
     Map.put(accumulator, format_key(key), deep_format_keys(value))
   end
+
   defp deep_format_key_value({key, value}, accumulator) do
     Map.put(accumulator, format_key(key), value)
   end
 
   @doc false
-  def format_key(k) when is_atom(k), do: k |> Atom.to_string |> format_key
+  def format_key(k) when is_atom(k), do: k |> Atom.to_string() |> format_key
   def format_key(key), do: do_format_key(key, @key_formatter)
 
   @doc false
   def do_format_key(key, :underscored), do: key
-  def do_format_key(key, :dasherized),  do: String.replace(key, "_", "-")
+  def do_format_key(key, :dasherized), do: String.replace(key, "_", "-")
   def do_format_key(key, {:custom, module, fun}), do: apply(module, fun, [key])
-  def do_format_key(key, {:custom, module, fun, _}), do: apply(module, fun, [key])
+
+  def do_format_key(key, {:custom, module, fun, _}),
+    do: apply(module, fun, [key])
 
   @doc false
   def format_type(string), do: do_format_type(string, @key_formatter)
@@ -53,12 +62,17 @@ defmodule JaSerializer.Formatter.Utils do
   @doc false
   def do_format_type(string, :dasherized), do: dasherize(string)
   def do_format_type(string, :underscored), do: underscore(string)
-  def do_format_type(string, {:custom, module, fun}), do: apply(module, fun, [string])
-  def do_format_type(string, {:custom, module, fun, _}), do: apply(module, fun, [string])
+
+  def do_format_type(string, {:custom, module, fun}),
+    do: apply(module, fun, [string])
+
+  def do_format_type(string, {:custom, module, fun, _}),
+    do: apply(module, fun, [string])
 
   @doc false
   def humanize(atom) when is_atom(atom),
     do: humanize(Atom.to_string(atom))
+
   def humanize(bin) when is_binary(bin) do
     bin =
       if String.ends_with?(bin, "_id") do
@@ -67,33 +81,35 @@ defmodule JaSerializer.Formatter.Utils do
         bin
       end
 
-    bin |> String.replace("_", " ") |> String.capitalize
+    bin |> String.replace("_", " ") |> String.capitalize()
   end
 
   @doc false
   def dasherize(""), do: ""
 
-  def dasherize(<<h, t :: binary>>) do
+  def dasherize(<<h, t::binary>>) do
     <<to_lower_char(h)>> <> do_dasherize(t, h)
   end
 
-  defp do_dasherize(<<h, t, rest :: binary>>, _) when h in ?A..?Z and not (t in ?A..?Z or t == ?.) do
+  defp do_dasherize(<<h, t, rest::binary>>, _)
+       when h in ?A..?Z and not (t in ?A..?Z or t == ?.) do
     <<?-, to_lower_char(h), t>> <> do_dasherize(rest, t)
   end
 
-  defp do_dasherize(<<h, t :: binary>>, prev) when h in ?A..?Z and not prev in ?A..?Z do
+  defp do_dasherize(<<h, t::binary>>, prev)
+       when h in ?A..?Z and not (prev in ?A..?Z) do
     <<?-, to_lower_char(h)>> <> do_dasherize(t, h)
   end
 
-  defp do_dasherize(<<?., t :: binary>>, _) do
+  defp do_dasherize(<<?., t::binary>>, _) do
     <<?/>> <> dasherize(t)
   end
 
-  defp do_dasherize(<<?_, t :: binary>>, _) do
+  defp do_dasherize(<<?_, t::binary>>, _) do
     <<?->> <> dasherize(t)
   end
 
-  defp do_dasherize(<<h, t :: binary>>, _) do
+  defp do_dasherize(<<h, t::binary>>, _) do
     <<to_lower_char(h)>> <> do_dasherize(t, h)
   end
 
@@ -104,23 +120,25 @@ defmodule JaSerializer.Formatter.Utils do
   @doc false
   def underscore(""), do: ""
 
-  def underscore(<<h, t :: binary>>) do
+  def underscore(<<h, t::binary>>) do
     <<to_lower_char(h)>> <> do_underscore(t, h)
   end
 
-  defp do_underscore(<<h, t, rest :: binary>>, _) when h in ?A..?Z and not (t in ?A..?Z or t == ?.) do
+  defp do_underscore(<<h, t, rest::binary>>, _)
+       when h in ?A..?Z and not (t in ?A..?Z or t == ?.) do
     <<?_, to_lower_char(h), t>> <> do_underscore(rest, t)
   end
 
-  defp do_underscore(<<h, t :: binary>>, prev) when h in ?A..?Z and not prev in ?A..?Z do
+  defp do_underscore(<<h, t::binary>>, prev)
+       when h in ?A..?Z and not (prev in ?A..?Z) do
     <<?_, to_lower_char(h)>> <> do_underscore(t, h)
   end
 
-  defp do_underscore(<<?., t :: binary>>, _) do
+  defp do_underscore(<<?., t::binary>>, _) do
     <<?/>> <> underscore(t)
   end
 
-  defp do_underscore(<<h, t :: binary>>, _) do
+  defp do_underscore(<<h, t::binary>>, _) do
     <<to_lower_char(h)>> <> do_underscore(t, h)
   end
 

--- a/lib/ja_serializer/param_parser.ex
+++ b/lib/ja_serializer/param_parser.ex
@@ -13,7 +13,8 @@ defimpl JaSerializer.ParamParser, for: List do
 end
 
 # Pass built in data types through
-defimpl JaSerializer.ParamParser, for: [BitString, Integer, Float, Atom, Function, PID, Port, Reference, Tuple] do
+defimpl JaSerializer.ParamParser,
+  for: [BitString, Integer, Float, Atom, Function, PID, Port, Reference, Tuple] do
   def parse(data), do: data
 end
 
@@ -23,10 +24,10 @@ end
 
 defimpl JaSerializer.ParamParser, for: Map do
   def parse(map) do
-    Enum.reduce map, %{}, fn({key, val}, map) ->
+    Enum.reduce(map, %{}, fn {key, val}, map ->
       key = JaSerializer.ParamParser.Utils.format_key(key)
       Map.put(map, key, JaSerializer.ParamParser.parse(val))
-    end
+    end)
   end
 end
 
@@ -35,7 +36,7 @@ defmodule JaSerializer.ParamParser.Utils do
 
   def format_key(key) do
     case Application.get_env(:ja_serializer, :key_format, :dasherized) do
-      :dasherized  -> dash_to_underscore(key)
+      :dasherized -> dash_to_underscore(key)
       :underscored -> key
       {:custom, module, _, fun} -> apply(module, fun, [key])
       _ -> key

--- a/lib/ja_serializer/params.ex
+++ b/lib/ja_serializer/params.ex
@@ -44,6 +44,7 @@ defmodule JaSerializer.Params do
 
   """
   def to_attributes(%{"data" => data}), do: to_attributes(data)
+
   def to_attributes(data) when is_map(data) do
     data
     |> parse_relationships
@@ -57,14 +58,16 @@ defmodule JaSerializer.Params do
   end
 
   defp parse_relationships(%{"relationships" => rels}) do
-    Enum.reduce rels, %{}, fn
-      ({name, %{"data" => nil}}, rel) ->
+    Enum.reduce(rels, %{}, fn
+      {name, %{"data" => nil}}, rel ->
         Map.put(rel, "#{name}_id", nil)
-      ({name, %{"data" => %{"id" => id}}}, rel) ->
+
+      {name, %{"data" => %{"id" => id}}}, rel ->
         Map.put(rel, "#{name}_id", id)
-      ({name, %{"data" => ids}}, rel) when is_list(ids) ->
-        Map.put(rel, "#{name}_ids", Enum.map(ids, &(&1["id"])))
-    end
+
+      {name, %{"data" => ids}}, rel when is_list(ids) ->
+        Map.put(rel, "#{name}_ids", Enum.map(ids, & &1["id"]))
+    end)
   end
 
   defp parse_relationships(_) do

--- a/lib/ja_serializer/phoenix_view.ex
+++ b/lib/ja_serializer/phoenix_view.ex
@@ -1,5 +1,4 @@
 defmodule JaSerializer.PhoenixView do
-
   @moduledoc """
   Use in your Phoenix.View to render jsonapi.org spec json.
 
@@ -68,20 +67,43 @@ defmodule JaSerializer.PhoenixView do
 
       # These will be deprecated in the future
       def render("index.json", data) do
-        IO.write :stderr, IO.ANSI.format([:red, :bright, "warning: Please use index.json-api instead. This will stop working in a future version.\n"])
+        IO.write(
+          :stderr,
+          IO.ANSI.format([
+            :red,
+            :bright,
+            "warning: Please use index.json-api instead. This will stop working in a future version.\n"
+          ])
+        )
+
         JaSerializer.PhoenixView.render(__MODULE__, data)
       end
 
       def render("show.json", data) do
-        IO.write :stderr, IO.ANSI.format([:red, :bright, "warning: Please use show.json-api instead. This will stop working in a future version.\n"])
+        IO.write(
+          :stderr,
+          IO.ANSI.format([
+            :red,
+            :bright,
+            "warning: Please use show.json-api instead. This will stop working in a future version.\n"
+          ])
+        )
+
         JaSerializer.PhoenixView.render(__MODULE__, data)
       end
 
       def render("errors.json", data) do
-        IO.write :stderr, IO.ANSI.format([:red, :bright, "warning: Please use errors.json-api instead. This will stop working in a future version.\n"])
+        IO.write(
+          :stderr,
+          IO.ANSI.format([
+            :red,
+            :bright,
+            "warning: Please use errors.json-api instead. This will stop working in a future version.\n"
+          ])
+        )
+
         JaSerializer.PhoenixView.render_errors(data)
       end
-
     end
   end
 
@@ -102,7 +124,8 @@ defmodule JaSerializer.PhoenixView do
   errors as described in `JaSerializer.ErrorSerializer`.
   """
   def render_errors(data) do
-    errors = (data[:data] || data[:errors])
+    errors = data[:data] || data[:errors]
+
     errors
     |> error_serializer
     |> apply(:format, [errors, data[:conn], data[:opts]])
@@ -119,30 +142,40 @@ defmodule JaSerializer.PhoenixView do
   defp find_struct(serializer, data) do
     singular = singular_type(serializer.type)
     plural = plural_type(serializer.type)
-    deprecated_struct  = data[:model] || data[singular] || data[plural]
+    deprecated_struct = data[:model] || data[singular] || data[plural]
 
     cond do
-      data[:data] -> data[:data]
+      data[:data] ->
+        data[:data]
+
       deprecated_struct ->
-        IO.write :stderr, IO.ANSI.format([:red, :bright,
-          "warning: Passing data via `:model`, `:#{plural}` or `:#{singular}`
+        IO.write(
+          :stderr,
+          IO.ANSI.format([
+            :red,
+            :bright,
+            "warning: Passing data via `:model`, `:#{plural}` or `:#{singular}`
           atoms to JaSerializer.PhoenixView has be deprecated. Please use
           `:data` instead. This will stop working in a future version.\n"
-        ])
+          ])
+        )
+
         deprecated_struct
-      is_nil(data[:data]) -> nil
+
+      is_nil(data[:data]) ->
+        nil
     end
   end
 
   defp singular_type(type) do
     type
-    |> Inflex.singularize
-    |> String.to_atom
+    |> Inflex.singularize()
+    |> String.to_atom()
   end
 
   defp plural_type(type) do
     type
-    |> Inflex.pluralize
-    |> String.to_atom
+    |> Inflex.pluralize()
+    |> String.to_atom()
   end
 end

--- a/lib/ja_serializer/relationship.ex
+++ b/lib/ja_serializer/relationship.ex
@@ -20,6 +20,7 @@ defmodule JaSerializer.AssociationNotLoadedError do
           end
         end
     """
+
     %JaSerializer.AssociationNotLoadedError{message: msg}
   end
 end
@@ -56,26 +57,24 @@ defmodule JaSerializer.Relationship do
     See JaSerializer.DSL.has_many/2 for information on defining different types
     of relationships.
     """
-    defstruct [
-      links:       [],
-      type:        nil,
-      serializer:  nil,
-      include:     false,
-      data:        nil,
-      identifiers: :when_included,
-      name:        nil
-    ]
+    defstruct links: [],
+              type: nil,
+              serializer: nil,
+              include: false,
+              data: nil,
+              identifiers: :when_included,
+              name: nil
 
     @doc false
     def from_dsl(name, dsl_opts) do
       %__MODULE__{
-        links:       dsl_opts[:links] || [],
-        type:        dsl_opts[:type],
-        serializer:  dsl_opts[:serializer],
-        include:     dsl_opts[:include],
-        data:        dsl_opts[:data] || name,
+        links: dsl_opts[:links] || [],
+        type: dsl_opts[:type],
+        serializer: dsl_opts[:serializer],
+        include: dsl_opts[:include],
+        data: dsl_opts[:data] || name,
         identifiers: dsl_opts[:identifiers] || :when_included,
-        name:        name
+        name: name
       }
     end
   end
@@ -110,26 +109,24 @@ defmodule JaSerializer.Relationship do
     See JaSerializer.DSL.has_many/2 for information on defining different types
     of relationships.
     """
-    defstruct [
-      links:       [],
-      type:        nil,
-      serializer:  nil,
-      include:     false,
-      data:        nil,
-      identifiers: :always,
-      name:        nil
-    ]
+    defstruct links: [],
+              type: nil,
+              serializer: nil,
+              include: false,
+              data: nil,
+              identifiers: :always,
+              name: nil
 
     @doc false
     def from_dsl(name, dsl_opts) do
       %__MODULE__{
-        links:       dsl_opts[:links] || [],
-        type:        dsl_opts[:type],
-        serializer:  dsl_opts[:serializer],
-        include:     dsl_opts[:include],
-        data:        dsl_opts[:data] || name,
+        links: dsl_opts[:links] || [],
+        type: dsl_opts[:type],
+        serializer: dsl_opts[:serializer],
+        include: dsl_opts[:include],
+        data: dsl_opts[:data] || name,
         identifiers: dsl_opts[:identifiers] || :always,
-        name:        name
+        name: name
       }
     end
   end
@@ -139,22 +136,30 @@ defmodule JaSerializer.Relationship do
     quote bind_quoted: [name: name, opts: opts] do
       unless Module.defines?(__MODULE__, {name, 2}, :def) do
         def unquote(name)(struct, _conn) do
-          JaSerializer.Relationship.get_data(struct, unquote(name), unquote(opts))
+          JaSerializer.Relationship.get_data(
+            struct,
+            unquote(name),
+            unquote(opts)
+          )
         end
       end
+
       defoverridable [{name, 2}]
     end
   end
 
   @error JaSerializer.AssociationNotLoadedError
   def get_data(struct, name, opts) do
-    rel = (opts[:field] || name)
+    rel = opts[:field] || name
+
     struct
     |> Map.get(rel)
     |> case do
-      %{__struct__: Ecto.Association.NotLoaded} -> raise @error, rel: rel, name: name
-      other -> other
+      %{__struct__: Ecto.Association.NotLoaded} ->
+        raise @error, rel: rel, name: name
+
+      other ->
+        other
     end
   end
-
 end

--- a/lib/ja_serializer/serializer.ex
+++ b/lib/ja_serializer/serializer.ex
@@ -39,7 +39,7 @@ defmodule JaSerializer.Serializer do
 
   """
 
-  @type id :: String.t | Integer
+  @type id :: String.t() | Integer
   @type data :: map
 
   @doc """
@@ -53,7 +53,7 @@ defmodule JaSerializer.Serializer do
 
       def id(struct, _conn), do: struct.slug
   """
-  @callback id(data, Plug.Conn.t) :: id
+  @callback id(data, Plug.Conn.t()) :: id
 
   @doc """
   The type to be used in the resource object.
@@ -71,7 +71,7 @@ defmodule JaSerializer.Serializer do
 
       def type(_post,_conn), do: "category"
   """
-  @callback type(map, Plug.Conn.t) :: String.t
+  @callback type(map, Plug.Conn.t()) :: String.t()
 
   @doc """
   Returns a map of attributes to be serialized.
@@ -119,7 +119,7 @@ defmodule JaSerializer.Serializer do
       UserSerializer.attributes(user, conn)
       # %{email: "...", name: "..."}
   """
-  @callback attributes(map, Plug.Conn.t) :: map
+  @callback attributes(map, Plug.Conn.t()) :: map
 
   @doc """
   Adds meta data to the individual resource being serialized.
@@ -132,7 +132,7 @@ defmodule JaSerializer.Serializer do
 
   The default implementation returns nil.
   """
-  @callback meta(map, Plug.Conn.t) :: map | nil
+  @callback meta(map, Plug.Conn.t()) :: map | nil
 
   @doc """
   A callback that should return a map of relationship structs.
@@ -159,12 +159,12 @@ defmodule JaSerializer.Serializer do
   When using the DSL this is defined for you based on the has_many and has_one
   macros.
   """
-  @callback relationships(map, Plug.Conn.t) :: map
+  @callback relationships(map, Plug.Conn.t()) :: map
 
   @doc """
   return links about this resource
   """
-  @callback links(map, Plug.Conn.t) :: map
+  @callback links(map, Plug.Conn.t()) :: map
 
   @doc """
   A special callback that can be used to preload related data.
@@ -187,7 +187,8 @@ defmodule JaSerializer.Serializer do
       end
 
   """
-  @callback preload(map | [map], Plug.Conn.t, nil | Keyword.t) :: map | [map]
+  @callback preload(map | [map], Plug.Conn.t(), nil | Keyword.t()) ::
+              map | [map]
 
   @doc false
   defmacro __using__(_) do
@@ -211,63 +212,66 @@ defmodule JaSerializer.Serializer do
   end
 
   defp define_default_type(module) do
-    type_from_module = module
-                        |> Module.split()
-                        |> List.last
-                        |> String.replace("Serializer", "")
-                        |> String.replace("View", "")
-                        |> JaSerializer.Formatter.Utils.format_type()
-                        |> pluralize_type(Application.get_env(:ja_serializer, :pluralize_types))
+    type_from_module =
+      module
+      |> Module.split()
+      |> List.last()
+      |> String.replace("Serializer", "")
+      |> String.replace("View", "")
+      |> JaSerializer.Formatter.Utils.format_type()
+      |> pluralize_type(Application.get_env(:ja_serializer, :pluralize_types))
+
     quote do
       def type, do: unquote(type_from_module)
       def type(_data, _conn), do: type()
-      defoverridable [type: 2, type: 0]
+      defoverridable type: 2, type: 0
     end
   end
 
   defp pluralize_type(type, true),
     do: Inflex.pluralize(type)
+
   defp pluralize_type(type, _bool), do: type
 
   defp define_default_id do
     quote do
       def id(data, _c), do: Map.get(data, :id)
-      defoverridable [id: 2]
+      defoverridable id: 2
     end
   end
 
   defp define_default_meta do
     quote do
       def meta(_struct, _conn), do: nil
-      defoverridable [meta: 2]
+      defoverridable meta: 2
     end
   end
 
   defp define_default_links do
     quote do
       def links(_struct, _conn), do: %{}
-      defoverridable [links: 2]
+      defoverridable links: 2
     end
   end
 
   defp define_default_attributes do
     quote do
       def attributes(data, _conn), do: Map.drop(data, [:id, :type, :__struct__])
-      defoverridable [attributes: 2]
+      defoverridable attributes: 2
     end
   end
 
   defp define_default_relationships do
     quote do
       def relationships(_struct, _conn), do: %{}
-      defoverridable [relationships: 2]
+      defoverridable relationships: 2
     end
   end
 
   defp define_default_preload do
     quote do
       def preload(data, _conn, _include_opts), do: data
-      defoverridable [preload: 3]
+      defoverridable preload: 3
     end
   end
 
@@ -282,11 +286,17 @@ defmodule JaSerializer.Serializer do
       end
 
       def format(data, conn, opts) do
-        IO.write :stderr, IO.ANSI.format([:red, :bright,
-          "warning: #{__MODULE__}.format/3 is deprecated.\n" <>
-          "Please use JaSerializer.format/4 instead, eg:\n" <>
-          "JaSerializer.format(#{__MODULE__}, data, conn, opts)\n"
-        ])
+        IO.write(
+          :stderr,
+          IO.ANSI.format([
+            :red,
+            :bright,
+            "warning: #{__MODULE__}.format/3 is deprecated.\n" <>
+              "Please use JaSerializer.format/4 instead, eg:\n" <>
+              "JaSerializer.format(#{__MODULE__}, data, conn, opts)\n"
+          ])
+        )
+
         JaSerializer.format(__MODULE__, data, conn, opts)
       end
     end

--- a/lib/mix/tasks/ja_serializer.gen.phx_api.ex
+++ b/lib/mix/tasks/ja_serializer.gen.phx_api.ex
@@ -1,15 +1,17 @@
 if Code.ensure_loaded?(Phoenix) and Code.ensure_loaded?(Mix.Phoenix.Context) do
   defmodule Mix.Tasks.JaSerializer.Gen.PhxApi do
     @shortdoc "Generates a controller and model for a JSON API based resource"
-    
+
     use Mix.Task
 
     alias Mix.Phoenix.Context
     alias Mix.Tasks.Phx.Gen
 
     def run(args) do
-      if Mix.Project.umbrella? do
-        Mix.raise "mix phx.gen.json can only be run inside an application directory"
+      if Mix.Project.umbrella?() do
+        Mix.raise(
+          "mix phx.gen.json can only be run inside an application directory"
+        )
       end
 
       {context, schema} = Gen.Context.build(args)
@@ -26,7 +28,7 @@ if Code.ensure_loaded?(Phoenix) and Code.ensure_loaded?(Mix.Phoenix.Context) do
     defp generator_paths do
       [
         ".",
-        Mix.Project.deps_path |> Path.join("..") |> Path.expand,
+        Mix.Project.deps_path() |> Path.join("..") |> Path.expand(),
         :ja_serializer,
         :phoenix
       ]
@@ -38,9 +40,11 @@ if Code.ensure_loaded?(Phoenix) and Code.ensure_loaded?(Mix.Phoenix.Context) do
       |> Kernel.++(context_files(context))
       |> Mix.Phoenix.prompt_for_conflicts()
     end
+
     defp context_files(%Context{generate?: true} = context) do
       Gen.Context.files_to_be_generated(context)
     end
+
     defp context_files(%Context{generate?: false}) do
       []
     end
@@ -51,57 +55,94 @@ if Code.ensure_loaded?(Phoenix) and Code.ensure_loaded?(Mix.Phoenix.Context) do
       web_path = to_string(schema.web_path)
 
       [
-        {:new_eex, "changeset_view.ex",      Path.join([web_prefix, "views/changeset_view.ex"])},
-        {:new_eex, "fallback_controller.ex", Path.join([web_prefix, "controllers/fallback_controller.ex"])},
+        {:new_eex, "changeset_view.ex",
+         Path.join([web_prefix, "views/changeset_view.ex"])},
+        {:new_eex, "fallback_controller.ex",
+         Path.join([web_prefix, "controllers/fallback_controller.ex"])}
       ]
     end
 
-    def ja_serializer_files_to_be_generated(%Context{schema: schema, context_app: context_app}) do
+    def ja_serializer_files_to_be_generated(%Context{
+          schema: schema,
+          context_app: context_app
+        }) do
       web_prefix = Mix.Phoenix.web_path(context_app)
       test_prefix = Mix.Phoenix.web_test_path(context_app)
       web_path = to_string(schema.web_path)
 
       [
-        {:eex,     "controller.ex",          Path.join([web_prefix, "controllers", web_path, "#{schema.singular}_controller.ex"])},
-        {:eex,     "view.ex",                Path.join([web_prefix, "views", web_path, "#{schema.singular}_view.ex"])},
-        {:eex,     "controller_test.exs",    Path.join([test_prefix, "controllers", web_path, "#{schema.singular}_controller_test.exs"])},
+        {:eex, "controller.ex",
+         Path.join([
+           web_prefix,
+           "controllers",
+           web_path,
+           "#{schema.singular}_controller.ex"
+         ])},
+        {:eex, "view.ex",
+         Path.join([web_prefix, "views", web_path, "#{schema.singular}_view.ex"])},
+        {:eex, "controller_test.exs",
+         Path.join([
+           test_prefix,
+           "controllers",
+           web_path,
+           "#{schema.singular}_controller_test.exs"
+         ])}
       ]
     end
 
     def copy_new_files(%Context{} = context, paths, binding) do
       files = files_to_be_generated(context)
-      Mix.Phoenix.copy_from paths, "priv/templates/phx.gen.json", binding, files
+
+      Mix.Phoenix.copy_from(
+        paths,
+        "priv/templates/phx.gen.json",
+        binding,
+        files
+      )
 
       files = ja_serializer_files_to_be_generated(context)
-      Mix.Phoenix.copy_from paths, "priv/templates/ja_serializer.gen.phx_api", binding, files
 
-      if context.generate?, do: Gen.Context.copy_new_files(context, paths, binding)
+      Mix.Phoenix.copy_from(
+        paths,
+        "priv/templates/ja_serializer.gen.phx_api",
+        binding,
+        files
+      )
+
+      if context.generate?,
+        do: Gen.Context.copy_new_files(context, paths, binding)
 
       context
     end
 
-    def print_shell_instructions(%Context{schema: schema, context_app: ctx_app} = context) do
+    def print_shell_instructions(
+          %Context{schema: schema, context_app: ctx_app} = context
+        ) do
       if schema.web_namespace do
-        Mix.shell.info """
+        Mix.shell().info("""
 
-        Add the resource to your #{schema.web_namespace} :api scope in #{Mix.Phoenix.web_path(ctx_app)}/router.ex:
+        Add the resource to your #{schema.web_namespace} :api scope in #{
+          Mix.Phoenix.web_path(ctx_app)
+        }/router.ex:
 
-            scope "/#{schema.web_path}", #{inspect Module.concat(context.web_module, schema.web_namespace)} do
+            scope "/#{schema.web_path}", #{
+          inspect(Module.concat(context.web_module, schema.web_namespace))
+        } do
               pipe_through :api
               ...
-              resources "/#{schema.plural}", #{inspect schema.alias}Controller
+              resources "/#{schema.plural}", #{inspect(schema.alias)}Controller
             end
-        """
+        """)
       else
-        Mix.shell.info """
+        Mix.shell().info("""
 
         Add the resource to your :api scope in lib/#{Mix.Phoenix.otp_app()}/web/router.ex:
 
-            resources "/#{schema.plural}", #{inspect schema.alias}Controller, except: [:new, :edit]
-        """
+            resources "/#{schema.plural}", #{inspect(schema.alias)}Controller, except: [:new, :edit]
+        """)
       end
+
       if context.generate?, do: Gen.Context.print_shell_instructions(context)
     end
-
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -2,16 +2,18 @@ defmodule JaSerializer.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :ja_serializer,
-     version: "0.13.0",
-     elixir: "~> 1.1",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
-     consolidate_protocols: Mix.env != :test,
-     source_url: "https://github.com/vt-elixir/ja_serializer",
-     package: package(),
-     description: description(),
-     deps: deps()]
+    [
+      app: :ja_serializer,
+      version: "0.13.0",
+      elixir: "~> 1.1",
+      build_embedded: Mix.env() == :prod,
+      start_permanent: Mix.env() == :prod,
+      consolidate_protocols: Mix.env() != :test,
+      source_url: "https://github.com/vt-elixir/ja_serializer",
+      package: package(),
+      description: description(),
+      deps: deps()
+    ]
   end
 
   # Configuration for the OTP application
@@ -31,7 +33,7 @@ defmodule JaSerializer.Mixfile do
       {:benchfella, "~> 0.3.0", only: :dev},
       {:ex_doc, "~> 0.7", only: :dev},
       {:dialyxir, "~> 0.3.5", only: :dev},
-      {:credo, "~> 0.4.11", only: :dev},
+      {:credo, "~> 0.4.11", only: :dev}
     ]
   end
 
@@ -41,7 +43,7 @@ defmodule JaSerializer.Mixfile do
       maintainers: ["Alan Peabody"],
       links: %{
         "GitHub" => "https://github.com/vt-elixir/ja_serializer"
-      },
+      }
     ]
   end
 

--- a/test/bench.exs
+++ b/test/bench.exs
@@ -14,7 +14,7 @@ defmodule BarSerializer do
   attributes []
 
   has_one :foo,
-  serializer: FooSerializer
+    serializer: FooSerializer
 end
 
 defmodule FooSerializer do
@@ -25,35 +25,40 @@ defmodule FooSerializer do
   attributes []
 
   has_many :bars,
-  include: true,
-  serializer: BarSerializer
+    include: true,
+    serializer: BarSerializer
 end
 
 defmodule Benchmark do
   def generate(a, b) do
     for m <- 0..a do
-      bars = for n <- 0..b do
-        %Bar{id: n, foo: %Foo{id: m, bars: []}}
-      end
+      bars =
+        for n <- 0..b do
+          %Bar{id: n, foo: %Foo{id: m, bars: []}}
+        end
+
       %Foo{id: m, bars: bars}
     end
   end
 
   def tc_avg(mod, fun, args, iters \\ 10) do
     {z, _} = :timer.tc(mod, fun, args)
-    {m, _} = Enum.reduce(0..iters, {z, 1}, fn _, {m, n} ->
-      IO.write :stderr, "."
-      {t, _} = :timer.tc(mod, fun, args)
-      {m + (t - m) / (n + 1), n + 1}
-    end)
-    IO.write :stderr, "\n"
+
+    {m, _} =
+      Enum.reduce(0..iters, {z, 1}, fn _, {m, n} ->
+        IO.write(:stderr, ".")
+        {t, _} = :timer.tc(mod, fun, args)
+        {m + (t - m) / (n + 1), n + 1}
+      end)
+
+    IO.write(:stderr, "\n")
     m
   end
 
   def humanize(n) do
     Enum.reduce_while(["ms", "s"], {n, "us"}, fn n_scale, {n, o_scale} ->
       if n > 1000 do
-        {:cont, {n/1000, n_scale}}
+        {:cont, {n / 1000, n_scale}}
       else
         {:halt, {n, o_scale}}
       end
@@ -61,16 +66,17 @@ defmodule Benchmark do
   end
 
   defp parse_int!(n) do
-    case Integer.parse n, 10 do
+    case Integer.parse(n, 10) do
       {n, ""} -> n
     end
   end
 
   def run do
-    [x, y] = System.argv |> Enum.map(&parse_int!/1)
+    [x, y] = System.argv() |> Enum.map(&parse_int!/1)
+
     tc_avg(FooSerializer, :format, [generate(x, y)], 25)
     |> humanize
   end
 end
 
-Benchmark.run |> IO.inspect
+Benchmark.run() |> IO.inspect()

--- a/test/ja_serializer/builder/included_test.exs
+++ b/test/ja_serializer/builder/included_test.exs
@@ -85,7 +85,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     c2 = %TestModel.Comment{id: "c2", body: "c2", author: p1}
     a1 = %TestModel.Article{id: "a1", title: "a1", author: p1, comments: [c1, c2]}
 
-    context = %{data: a1, conn: %{}, serializer: ArticleSerializer, opts: []}
+    context = %{data: a1, conn: %{}, serializer: ArticleSerializer, opts: %{}}
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
     includes = JaSerializer.Builder.Included.build(context, primary_resource)
 
@@ -109,7 +109,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     c2 = %TestModel.Comment{id: "c2", body: "c2", author: p1}
     a1 = %TestModel.Article{id: "a1", title: "a1", author: p1, comments: [c1, c2]}
 
-    context = %{data: a1, conn: %{}, serializer: ArticleSerializer, opts: []}
+    context = %{data: a1, conn: %{}, serializer: ArticleSerializer, opts: %{}}
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
     includes = JaSerializer.Builder.Included.build(context, primary_resource)
 
@@ -129,7 +129,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     c1 = %TestModel.Comment{id: "c1", body: "c1"}
     a1 = %TestModel.Article{id: "a1", title: "a1", comments: [c1]}
 
-    context = %{data: a1, conn: %{}, serializer: DeprecatedArticleSerializer, opts: []}
+    context = %{data: a1, conn: %{}, serializer: DeprecatedArticleSerializer, opts: %{}}
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
     includes = JaSerializer.Builder.Included.build(context, primary_resource)
 
@@ -241,7 +241,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     a1 = %TestModel.Article{id: "a1", title: "a1", body: "a1", author: p1}
 
     fields = %{"articles" => "title", "people" => "first_name"}
-    opts = [fields: fields]
+    opts = %{fields: fields}
     context = %{data: a1, conn: %{}, serializer: ArticleSerializer, opts: opts}
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
     includes = JaSerializer.Builder.Included.build(context, primary_resource)
@@ -272,7 +272,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     a1 = %TestModel.Article{id: "a1", title: "a1", body: "a1", author: p1}
 
     fields = %{"articles" => "title"}
-    opts = [fields: fields]
+    opts = %{fields: fields}
     context = %{data: a1, conn: %{}, serializer: ArticleSerializer, opts: opts}
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
     includes = JaSerializer.Builder.Included.build(context, primary_resource)

--- a/test/ja_serializer/builder/included_test.exs
+++ b/test/ja_serializer/builder/included_test.exs
@@ -6,12 +6,15 @@ defmodule JaSerializer.Builder.IncludedTest do
 
     def type, do: "articles"
     attributes [:title]
+
     has_many :comments,
       serializer: JaSerializer.Builder.IncludedTest.CommentSerializer,
       include: true
+
     has_one :author,
       serializer: JaSerializer.Builder.IncludedTest.PersonSerializer,
       include: true
+
     has_many :tags,
       serializer: JaSerializer.Builder.IncludedTest.TagSerializer
   end
@@ -21,6 +24,7 @@ defmodule JaSerializer.Builder.IncludedTest do
 
     def type, do: "articles"
     attributes [:title]
+
     has_many :comments,
       include: JaSerializer.Builder.IncludedTest.CommentSerializer
   end
@@ -30,12 +34,15 @@ defmodule JaSerializer.Builder.IncludedTest do
 
     def type, do: "articles"
     attributes [:title]
+
     has_many :comments,
       serializer: JaSerializer.Builder.IncludedTest.CommentSerializer,
       identifiers: :when_included
+
     has_one :author,
       serializer: JaSerializer.Builder.IncludedTest.PersonSerializer,
       identifiers: :when_included
+
     has_many :tags,
       serializer: JaSerializer.Builder.IncludedTest.TagSerializer,
       identifiers: :always
@@ -45,6 +52,7 @@ defmodule JaSerializer.Builder.IncludedTest do
     use JaSerializer
     def type, do: "people"
     attributes [:first_name, :last_name]
+
     has_one :publishing_agent,
       serializer: JaSerializer.Builder.IncludedTest.PersonSerializer,
       include: false
@@ -61,20 +69,24 @@ defmodule JaSerializer.Builder.IncludedTest do
     def type, do: "comments"
     location "/comments/:id"
     attributes [:body]
+
     has_one :author,
       serializer: JaSerializer.Builder.IncludedTest.PersonSerializer,
       include: true
+
     has_many :comments,
       serializer: JaSerializer.Builder.IncludedTest.CommentSerializer,
       include: true
+
     has_many :tags,
       serializer: JaSerializer.Builder.IncludedTest.TagSerializer
   end
 
   setup do
-    on_exit fn ->
+    on_exit(fn ->
       Application.delete_env(:ja_serializer, :key_format)
-    end
+    end)
+
     :ok
   end
 
@@ -83,19 +95,25 @@ defmodule JaSerializer.Builder.IncludedTest do
     p2 = %TestModel.Person{id: "p2", first_name: "p2"}
     c1 = %TestModel.Comment{id: "c1", body: "c1", author: p2}
     c2 = %TestModel.Comment{id: "c2", body: "c2", author: p1}
-    a1 = %TestModel.Article{id: "a1", title: "a1", author: p1, comments: [c1, c2]}
+
+    a1 = %TestModel.Article{
+      id: "a1",
+      title: "a1",
+      author: p1,
+      comments: [c1, c2]
+    }
 
     context = %{data: a1, conn: %{}, serializer: ArticleSerializer, opts: %{}}
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
     includes = JaSerializer.Builder.Included.build(context, primary_resource)
 
-    ids = Enum.map(includes, &(&1.id))
+    ids = Enum.map(includes, & &1.id)
     assert "p1" in ids
     assert "p2" in ids
     assert "c1" in ids
     assert "c2" in ids
 
-    assert [_,_,_,_] = includes
+    assert [_, _, _, _] = includes
 
     # Formatted
     json = JaSerializer.format(ArticleSerializer, a1)
@@ -107,14 +125,20 @@ defmodule JaSerializer.Builder.IncludedTest do
     p1 = %TestModel.Person{id: "p1", first_name: "p1"}
     c1 = %TestModel.Comment{id: "c1", body: "c1", author: p1}
     c2 = %TestModel.Comment{id: "c2", body: "c2", author: p1}
-    a1 = %TestModel.Article{id: "a1", title: "a1", author: p1, comments: [c1, c2]}
+
+    a1 = %TestModel.Article{
+      id: "a1",
+      title: "a1",
+      author: p1,
+      comments: [c1, c2]
+    }
 
     context = %{data: a1, conn: %{}, serializer: ArticleSerializer, opts: %{}}
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
     includes = JaSerializer.Builder.Included.build(context, primary_resource)
 
-    ids = Enum.map(includes, &(&1.id))
-    assert [_,_,_] = includes
+    ids = Enum.map(includes, & &1.id)
+    assert [_, _, _] = includes
     assert "p1" in ids
     assert "c1" in ids
     assert "c2" in ids
@@ -129,11 +153,17 @@ defmodule JaSerializer.Builder.IncludedTest do
     c1 = %TestModel.Comment{id: "c1", body: "c1"}
     a1 = %TestModel.Article{id: "a1", title: "a1", comments: [c1]}
 
-    context = %{data: a1, conn: %{}, serializer: DeprecatedArticleSerializer, opts: %{}}
+    context = %{
+      data: a1,
+      conn: %{},
+      serializer: DeprecatedArticleSerializer,
+      opts: %{}
+    }
+
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
     includes = JaSerializer.Builder.Included.build(context, primary_resource)
 
-    ids = Enum.map(includes, &(&1.id))
+    ids = Enum.map(includes, & &1.id)
     assert [_] = includes
     assert "c1" in ids
 
@@ -150,23 +180,43 @@ defmodule JaSerializer.Builder.IncludedTest do
     c1 = %TestModel.Comment{id: "c1", body: "c1", author: p2}
     c2 = %TestModel.Comment{id: "c2", body: "c2", author: p1}
     t1 = %TestModel.Tag{id: "t1", tag: "tag1"}
-    a1 = %TestModel.Article{id: "a1", title: "a1", author: p1, comments: [c1, c2], tags: [t1]}
+
+    a1 = %TestModel.Article{
+      id: "a1",
+      title: "a1",
+      author: p1,
+      comments: [c1, c2],
+      tags: [t1]
+    }
 
     opts = %{include: [author: []]}
-    context = %{data: a1, conn: %{}, serializer: OptionalIncludeArticleSerializer, opts: opts}
+
+    context = %{
+      data: a1,
+      conn: %{},
+      serializer: OptionalIncludeArticleSerializer,
+      opts: opts
+    }
+
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
     includes = JaSerializer.Builder.Included.build(context, primary_resource)
 
-    ids = Enum.map(includes, &(&1.id))
+    ids = Enum.map(includes, & &1.id)
     assert [_] = ids
     assert "p1" in ids
 
     # Formatted
-    json = JaSerializer.format(OptionalIncludeArticleSerializer, a1, %{}, include: "author")
+    json =
+      JaSerializer.format(OptionalIncludeArticleSerializer, a1, %{},
+        include: "author"
+      )
+
     assert %{} = json["data"]
     assert [_] = json["included"]
 
-    assert [%{"id" => "t1", "type" => "tags"}] == json["data"]["relationships"]["tags"]["data"]
+    assert [%{"id" => "t1", "type" => "tags"}] ==
+             json["data"]["relationships"]["tags"]["data"]
+
     refute json["data"]["relationships"]["comments"]["data"]
   end
 
@@ -175,14 +225,27 @@ defmodule JaSerializer.Builder.IncludedTest do
     p2 = %TestModel.Person{id: "p2", first_name: "p2"}
     c1 = %TestModel.Comment{id: "c1", body: "c1", author: p2}
     c2 = %TestModel.Comment{id: "c2", body: "c2", author: p1}
-    a1 = %TestModel.Article{id: "a1", title: "a1", author: p1, comments: [c1, c2]}
+
+    a1 = %TestModel.Article{
+      id: "a1",
+      title: "a1",
+      author: p1,
+      comments: [c1, c2]
+    }
 
     opts = %{include: [author: [], comments: [author: []]]}
-    context = %{data: a1, conn: %{}, serializer: OptionalIncludeArticleSerializer, opts: opts}
+
+    context = %{
+      data: a1,
+      conn: %{},
+      serializer: OptionalIncludeArticleSerializer,
+      opts: opts
+    }
+
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
     includes = JaSerializer.Builder.Included.build(context, primary_resource)
 
-    ids = Enum.map(includes, &(&1.id))
+    ids = Enum.map(includes, & &1.id)
     assert [_, _, _, _] = ids
     assert "p1" in ids
     assert "p2" in ids
@@ -190,7 +253,11 @@ defmodule JaSerializer.Builder.IncludedTest do
     assert "c2" in ids
 
     # Formatted
-    json = JaSerializer.format(OptionalIncludeArticleSerializer, a1, %{}, include: "author,comments.author")
+    json =
+      JaSerializer.format(OptionalIncludeArticleSerializer, a1, %{},
+        include: "author,comments.author"
+      )
+
     assert %{} = json["data"]
     assert [_, _, _, _] = json["included"]
   end
@@ -200,14 +267,28 @@ defmodule JaSerializer.Builder.IncludedTest do
     t1 = %TestModel.Tag{id: "t1", tag: "t1"}
     t2 = %TestModel.Tag{id: "t2", tag: "t2"}
     c1 = %TestModel.Comment{id: "c1", body: "c1", author: p1, tags: [t2]}
-    a1 = %TestModel.Article{id: "a1", title: "a1", author: p1, comments: [c1], tags: [t1]}
+
+    a1 = %TestModel.Article{
+      id: "a1",
+      title: "a1",
+      author: p1,
+      comments: [c1],
+      tags: [t1]
+    }
 
     opts = %{include: [tags: [], comments: [author: [], tags: []]]}
-    context = %{data: a1, conn: %{}, serializer: OptionalIncludeArticleSerializer, opts: opts}
+
+    context = %{
+      data: a1,
+      conn: %{},
+      serializer: OptionalIncludeArticleSerializer,
+      opts: opts
+    }
+
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
     includes = JaSerializer.Builder.Included.build(context, primary_resource)
 
-    ids = Enum.map(includes, &(&1.id))
+    ids = Enum.map(includes, & &1.id)
     assert [_, _, _, _] = ids
     assert "p1" in ids
     assert "c1" in ids
@@ -215,21 +296,26 @@ defmodule JaSerializer.Builder.IncludedTest do
     assert "t2" in ids
 
     # Formatted
-    json = JaSerializer.format(OptionalIncludeArticleSerializer, a1, %{}, include: "tags,comments.author,comments.tags")
+    json =
+      JaSerializer.format(OptionalIncludeArticleSerializer, a1, %{},
+        include: "tags,comments.author,comments.tags"
+      )
+
     assert %{} = json["data"]
 
     included = json["included"]
     assert [_, _, _, _] = included
 
-    resource_by_id_by_type = Enum.reduce(
-      included,
-      %{},
-      fn resource = %{"id" => id, "type" => type}, resource_by_id_by_type ->
-        resource_by_id_by_type
-        |> Map.put_new(type, %{})
-        |> put_in([type, id], resource)
-      end
-    )
+    resource_by_id_by_type =
+      Enum.reduce(
+        included,
+        %{},
+        fn resource = %{"id" => id, "type" => type}, resource_by_id_by_type ->
+          resource_by_id_by_type
+          |> Map.put_new(type, %{})
+          |> put_in([type, id], resource)
+        end
+      )
 
     c1_resource = resource_by_id_by_type["comments"]["c1"]
     assert %{"data" => c1_tags_data} = c1_resource["relationships"]["tags"]
@@ -278,13 +364,13 @@ defmodule JaSerializer.Builder.IncludedTest do
     includes = JaSerializer.Builder.Included.build(context, primary_resource)
 
     assert [person] = includes
-    assert [_,_] = person.attributes
+    assert [_, _] = person.attributes
 
     # Formatted
     json = JaSerializer.format(ArticleSerializer, a1, %{}, fields: fields)
     assert [formatted_person] = json["included"]
     person_attrs = Map.keys(formatted_person["attributes"])
-    assert [_,_] = person_attrs
+    assert [_, _] = person_attrs
     assert "first-name" in person_attrs
     assert "last-name" in person_attrs
   end
@@ -295,25 +381,48 @@ defmodule JaSerializer.Builder.IncludedTest do
     c1 = %TestModel.Comment{id: "c1", body: "c1", author: p2}
     a1 = %TestModel.Article{id: "a1", title: "a1", author: p2, comments: [c1]}
 
-    json = JaSerializer.format(ArticleSerializer, a1, %{}, include: "author.publishing-agent")
+    json =
+      JaSerializer.format(ArticleSerializer, a1, %{},
+        include: "author.publishing-agent"
+      )
+
     assert includes = json["included"]
-    ids = Enum.map(includes, &(Map.get(&1, "id")))
+    ids = Enum.map(includes, &Map.get(&1, "id"))
     assert "p1" in ids
 
     Application.put_env(:ja_serializer, :key_format, :dasherized)
-    json = JaSerializer.format(ArticleSerializer, a1, %{}, include: "author.publishing-agent")
-    ids = Enum.map(json["included"], &(Map.get(&1, "id")))
+
+    json =
+      JaSerializer.format(ArticleSerializer, a1, %{},
+        include: "author.publishing-agent"
+      )
+
+    ids = Enum.map(json["included"], &Map.get(&1, "id"))
     assert "p1" in ids
 
     Application.put_env(:ja_serializer, :key_format, :underscored)
-    json = JaSerializer.format(ArticleSerializer, a1, %{}, include: "author.publishing-agent")
-    ids = Enum.map(json["included"], &(Map.get(&1, "id")))
-    assert not "p1" in ids
 
-    Application.put_env(:ja_serializer, :key_format, {:custom, Macro, nil, :underscore})
-    json = JaSerializer.format(ArticleSerializer, a1, %{}, include: "author.publishing-agent")
-    ids = Enum.map(json["included"], &(Map.get(&1, "id")))
-    assert not "p1" in ids
+    json =
+      JaSerializer.format(ArticleSerializer, a1, %{},
+        include: "author.publishing-agent"
+      )
+
+    ids = Enum.map(json["included"], &Map.get(&1, "id"))
+    assert not ("p1" in ids)
+
+    Application.put_env(
+      :ja_serializer,
+      :key_format,
+      {:custom, Macro, nil, :underscore}
+    )
+
+    json =
+      JaSerializer.format(ArticleSerializer, a1, %{},
+        include: "author.publishing-agent"
+      )
+
+    ids = Enum.map(json["included"], &Map.get(&1, "id"))
+    assert not ("p1" in ids)
   end
 
   test "non-existent include that is serialized into resource identifier results in no includes being added" do
@@ -321,7 +430,7 @@ defmodule JaSerializer.Builder.IncludedTest do
 
     json = JaSerializer.format(ArticleSerializer, a1, %{}, include: "author")
     keys = Map.keys(json)
-    assert not "included" in keys
+    assert not ("included" in keys)
     assert json["data"]["relationships"]["author"]["data"]["id"] == "p1"
   end
 end

--- a/test/ja_serializer/builder/link_test.exs
+++ b/test/ja_serializer/builder/link_test.exs
@@ -30,7 +30,11 @@ defmodule JaSerializer.Builder.LinkTest do
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
 
     %JaSerializer.Builder.ResourceObject{
-      relationships: [%JaSerializer.Builder.Relationship{:links => [%JaSerializer.Builder.Link{href: href}]}]
+      relationships: [
+        %JaSerializer.Builder.Relationship{
+          :links => [%JaSerializer.Builder.Link{href: href}]
+        }
+      ]
     } = primary_resource
 
     assert href == "comments?article_id=a1"
@@ -45,7 +49,11 @@ defmodule JaSerializer.Builder.LinkTest do
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
 
     %JaSerializer.Builder.ResourceObject{
-      relationships: [%JaSerializer.Builder.Relationship{:links => [%JaSerializer.Builder.Link{href: href}]}]
+      relationships: [
+        %JaSerializer.Builder.Relationship{
+          :links => [%JaSerializer.Builder.Link{href: href}]
+        }
+      ]
     } = primary_resource
 
     assert href == "articles/a1/comments"

--- a/test/ja_serializer/builder/link_test.exs
+++ b/test/ja_serializer/builder/link_test.exs
@@ -26,7 +26,7 @@ defmodule JaSerializer.Builder.LinkTest do
     c2 = %TestModel.Comment{id: "c2", body: "c2"}
     a1 = %TestModel.Article{id: "a1", title: "a1", comments: [c1, c2]}
 
-    context = %{data: a1, conn: %{}, serializer: ArticleSerializer, opts: []}
+    context = %{data: a1, conn: %{}, serializer: ArticleSerializer, opts: %{}}
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
 
     %JaSerializer.Builder.ResourceObject{
@@ -41,7 +41,7 @@ defmodule JaSerializer.Builder.LinkTest do
     c2 = %TestModel.Comment{id: "c2", body: "c2"}
     a1 = %TestModel.Article{id: "a1", title: "a1", comments: [c1, c2]}
 
-    context = %{data: a1, conn: %{}, serializer: PostSerializer, opts: []}
+    context = %{data: a1, conn: %{}, serializer: PostSerializer, opts: %{}}
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
 
     %JaSerializer.Builder.ResourceObject{

--- a/test/ja_serializer/builder/pagination_links_test.exs
+++ b/test/ja_serializer/builder/pagination_links_test.exs
@@ -3,13 +3,12 @@ defmodule JaSerializer.Builder.PaginationLinksTest do
   alias JaSerializer.Builder.PaginationLinks
 
   setup do
-    on_exit fn ->
-
-    Application.delete_env(:ja_serializer, :page_key)
-    Application.delete_env(:ja_serializer, :page_base_url)
-    Application.delete_env(:ja_serializer, :page_size_key)
-    Application.delete_env(:ja_serializer, :page_number_key)
-    end
+    on_exit(fn ->
+      Application.delete_env(:ja_serializer, :page_key)
+      Application.delete_env(:ja_serializer, :page_base_url)
+      Application.delete_env(:ja_serializer, :page_size_key)
+      Application.delete_env(:ja_serializer, :page_number_key)
+    end)
   end
 
   test "pagination" do
@@ -18,6 +17,7 @@ defmodule JaSerializer.Builder.PaginationLinksTest do
       size: 20,
       total: 30
     }
+
     conn = %Plug.Conn{query_params: %{}}
     links = PaginationLinks.build(data, conn)
     assert URI.decode(links[:first]) == "?page[number]=1&page[size]=20"
@@ -36,6 +36,7 @@ defmodule JaSerializer.Builder.PaginationLinksTest do
       size: 20,
       total: 30
     }
+
     conn = %Plug.Conn{query_params: %{}}
     links = PaginationLinks.build(data, conn)
 
@@ -51,7 +52,9 @@ defmodule JaSerializer.Builder.PaginationLinksTest do
       size: 20,
       total: 30
     }
+
     conn = %Plug.Conn{query_params: %{}}
+
     links =
       data
       |> PaginationLinks.build(conn)
@@ -67,7 +70,9 @@ defmodule JaSerializer.Builder.PaginationLinksTest do
       size: 20,
       total: 30
     }
+
     conn = %Plug.Conn{query_params: %{}}
+
     links =
       data
       |> PaginationLinks.build(conn)
@@ -83,7 +88,9 @@ defmodule JaSerializer.Builder.PaginationLinksTest do
       size: 20,
       total: 30
     }
+
     conn = %Plug.Conn{query_params: %{}}
+
     links =
       data
       |> PaginationLinks.build(conn)
@@ -99,7 +106,9 @@ defmodule JaSerializer.Builder.PaginationLinksTest do
       size: 20,
       total: 0
     }
+
     conn = %Plug.Conn{query_params: %{}}
+
     links =
       data
       |> PaginationLinks.build(conn)
@@ -115,13 +124,16 @@ defmodule JaSerializer.Builder.PaginationLinksTest do
       size: 20,
       total: 30
     }
+
     conn = %Plug.Conn{
       query_params: %{"filter" => %{"foo" => "bar"}},
       request_path: "/api/v1/posts/"
     }
+
     links = PaginationLinks.build(data, conn)
 
-    assert links[:first] == "/api/v1/posts/?filter[foo]=bar&page[number]=1&page[size]=20"
+    assert links[:first] ==
+             "/api/v1/posts/?filter[foo]=bar&page[number]=1&page[size]=20"
   end
 
   test "url opts override conn url, old page params ignored" do
@@ -131,10 +143,12 @@ defmodule JaSerializer.Builder.PaginationLinksTest do
       total: 30,
       base_url: "/api/v2/posts"
     }
+
     conn = %Plug.Conn{
       query_params: %{"page" => %{"page" => 1}},
       request_path: "/api/v1/posts/"
     }
+
     links = PaginationLinks.build(data, conn)
 
     assert links[:first] == "/api/v2/posts?page[number]=1&page[size]=20"
@@ -146,35 +160,53 @@ defmodule JaSerializer.Builder.PaginationLinksTest do
     data = %{
       number: 1,
       size: 20,
-      total: 30,
+      total: 30
     }
+
     conn = %Plug.Conn{
-      query_params: %{"number" => 4},
+      query_params: %{"number" => 4}
     }
+
     links = PaginationLinks.build(data, conn)
 
     assert links[:self] == "?number=1&size=20"
   end
 
   test "base_url can be configured globally" do
-    Application.put_env(:ja_serializer, :page_base_url, "http://api.example.com")
+    Application.put_env(
+      :ja_serializer,
+      :page_base_url,
+      "http://api.example.com"
+    )
 
     data = %{
       number: 10,
       size: 20,
       total: 30
     }
+
     conn = %Plug.Conn{query_params: %{}}
     links = PaginationLinks.build(data, conn)
 
-    assert URI.decode(links[:first]) == "http://api.example.com?page[number]=1&page[size]=20"
-    assert URI.decode(links[:prev]) == "http://api.example.com?page[number]=9&page[size]=20"
-    assert URI.decode(links[:next]) == "http://api.example.com?page[number]=11&page[size]=20"
-    assert URI.decode(links[:last]) == "http://api.example.com?page[number]=30&page[size]=20"
+    assert URI.decode(links[:first]) ==
+             "http://api.example.com?page[number]=1&page[size]=20"
+
+    assert URI.decode(links[:prev]) ==
+             "http://api.example.com?page[number]=9&page[size]=20"
+
+    assert URI.decode(links[:next]) ==
+             "http://api.example.com?page[number]=11&page[size]=20"
+
+    assert URI.decode(links[:last]) ==
+             "http://api.example.com?page[number]=30&page[size]=20"
   end
 
   test "base_url can be overridden locally" do
-    Application.put_env(:ja_serializer, :page_base_url, "http://api.example.com")
+    Application.put_env(
+      :ja_serializer,
+      :page_base_url,
+      "http://api.example.com"
+    )
 
     data = %{
       number: 10,
@@ -182,12 +214,20 @@ defmodule JaSerializer.Builder.PaginationLinksTest do
       total: 30,
       base_url: "http://api2.example.com"
     }
+
     conn = %Plug.Conn{query_params: %{}}
     links = PaginationLinks.build(data, conn)
 
-    assert URI.decode(links[:first]) == "http://api2.example.com?page[number]=1&page[size]=20"
-    assert URI.decode(links[:prev]) == "http://api2.example.com?page[number]=9&page[size]=20"
-    assert URI.decode(links[:next]) == "http://api2.example.com?page[number]=11&page[size]=20"
-    assert URI.decode(links[:last]) == "http://api2.example.com?page[number]=30&page[size]=20"
+    assert URI.decode(links[:first]) ==
+             "http://api2.example.com?page[number]=1&page[size]=20"
+
+    assert URI.decode(links[:prev]) ==
+             "http://api2.example.com?page[number]=9&page[size]=20"
+
+    assert URI.decode(links[:next]) ==
+             "http://api2.example.com?page[number]=11&page[size]=20"
+
+    assert URI.decode(links[:last]) ==
+             "http://api2.example.com?page[number]=30&page[size]=20"
   end
 end

--- a/test/ja_serializer/builder/relationship_test.exs
+++ b/test/ja_serializer/builder/relationship_test.exs
@@ -9,6 +9,7 @@ defmodule JaSerializer.Builder.RelationshipTest do
 
     def type, do: "articles"
     attributes [:title]
+
     has_many :comments,
       serializer: CommentSerializer,
       include: true
@@ -24,15 +25,16 @@ defmodule JaSerializer.Builder.RelationshipTest do
 
   defmodule FooSerializer do
     use JaSerializer
+
     has_many :bars,
-             type: "bar",
-             links: [
-               self: "/foo/:id/relationships/bars",
-               related: "/foo/:id/bars"
-             ]
+      type: "bar",
+      links: [
+        self: "/foo/:id/relationships/bars",
+        related: "/foo/:id/bars"
+      ]
 
     has_one :baz, field: :baz_id, type: "baz"
-    def bars(_,_), do: [1,2,3]
+    def bars(_, _), do: [1, 2, 3]
   end
 
   test "custom id def respected in relationship data" do
@@ -47,9 +49,9 @@ defmodule JaSerializer.Builder.RelationshipTest do
       relationships: [%JaSerializer.Builder.Relationship{:data => rel_data}]
     } = primary_resource
 
-    assert [_,_] = rel_data
+    assert [_, _] = rel_data
 
-    ids = Enum.map(rel_data, &(&1.id))
+    ids = Enum.map(rel_data, & &1.id)
     assert "c1" in ids
     assert "c2" in ids
 
@@ -58,7 +60,7 @@ defmodule JaSerializer.Builder.RelationshipTest do
     assert %{"relationships" => %{"comments" => comments}} = json["data"]
     assert [_, _] = comments["data"]
 
-    formatted_ids = Enum.map(comments["data"], &(&1["id"]))
+    formatted_ids = Enum.map(comments["data"], & &1["id"])
     assert "c1" in formatted_ids
     assert "c2" in formatted_ids
   end
@@ -66,22 +68,22 @@ defmodule JaSerializer.Builder.RelationshipTest do
   test "building a self link Relationship is possible along with the 'related'" do
     json = JaSerializer.format(FooSerializer, %{baz_id: 1, id: 1})
     rel_links = json["data"]["relationships"]["bars"]["links"]
-    assert  "/foo/1/relationships/bars" = rel_links["self"]
-    assert  "/foo/1/bars" = rel_links["related"]
+    assert "/foo/1/relationships/bars" = rel_links["self"]
+    assert "/foo/1/bars" = rel_links["related"]
   end
 
   test "building relationships from ids works" do
     json = JaSerializer.format(FooSerializer, %{baz_id: 1, id: 1})
     assert %{"relationships" => %{"bars" => bars, "baz" => baz}} = json["data"]
     assert baz["data"]["id"] == "1"
-    assert [bar, _, _ ] = bars["data"]
+    assert [bar, _, _] = bars["data"]
     assert bar["id"] == "1"
   end
 
   test "identifiers are included if type passed in" do
     comments = %HasMany{
       type: "comment",
-      data: [1,2,3]
+      data: [1, 2, 3]
     }
 
     context = %{conn: %{}, opts: %{}}
@@ -92,7 +94,7 @@ defmodule JaSerializer.Builder.RelationshipTest do
   test "identifiers are included if serializer is passed in and include is true" do
     comments = %HasMany{
       serializer: CommentSerializer,
-      data: [1,2,3],
+      data: [1, 2, 3],
       include: true
     }
 
@@ -104,7 +106,7 @@ defmodule JaSerializer.Builder.RelationshipTest do
   test "identifiers are included if serializer is passed in & name is in the include param" do
     comments = %HasMany{
       serializer: CommentSerializer,
-      data: [1,2,3],
+      data: [1, 2, 3],
       identifiers: :always
     }
 
@@ -116,7 +118,7 @@ defmodule JaSerializer.Builder.RelationshipTest do
   test "identifiers are included if the serializer is passed in & name is not in include parama & identifiers is always" do
     comments = %HasMany{
       serializer: CommentSerializer,
-      data: [1,2,3],
+      data: [1, 2, 3],
       identifiers: :always
     }
 
@@ -148,7 +150,11 @@ defmodule JaSerializer.Builder.RelationshipTest do
   end
 
   test "skipping relationship building with `relationships: false`" do
-    json = JaSerializer.format(FooSerializer, %{baz_id: 1, id: 1}, %{}, relationships: false)
+    json =
+      JaSerializer.format(FooSerializer, %{baz_id: 1, id: 1}, %{},
+        relationships: false
+      )
+
     refute Map.has_key?(json["data"], "relationships")
   end
 end

--- a/test/ja_serializer/builder/relationship_test.exs
+++ b/test/ja_serializer/builder/relationship_test.exs
@@ -40,7 +40,7 @@ defmodule JaSerializer.Builder.RelationshipTest do
     c2 = %TestModel.CustomIdComment{comment_id: "c2", body: "c2"}
     a1 = %TestModel.Article{id: "a1", title: "a1", comments: [c1, c2]}
 
-    context = %{data: a1, conn: %{}, serializer: ArticleSerializer, opts: []}
+    context = %{data: a1, conn: %{}, serializer: ArticleSerializer, opts: %{}}
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
 
     %JaSerializer.Builder.ResourceObject{
@@ -83,7 +83,8 @@ defmodule JaSerializer.Builder.RelationshipTest do
       type: "comment",
       data: [1,2,3]
     }
-    context = %{conn: %{}, opts: []}
+
+    context = %{conn: %{}, opts: %{}}
     rel = Relationship.build({:comments, comments}, context)
     assert [_ri1, _ri2, _ri3] = rel.data
   end
@@ -94,7 +95,8 @@ defmodule JaSerializer.Builder.RelationshipTest do
       data: [1,2,3],
       include: true
     }
-    context = %{conn: %{}, opts: []}
+
+    context = %{conn: %{}, opts: %{}}
     rel = Relationship.build({:comments, comments}, context)
     assert [_ri1, _ri2, _ri3] = rel.data
   end
@@ -105,7 +107,8 @@ defmodule JaSerializer.Builder.RelationshipTest do
       data: [1,2,3],
       identifiers: :always
     }
-    context = %{conn: %{}, opts: [include: [:comments]]}
+
+    context = %{conn: %{}, opts: %{include: [:comments]}}
     rel = Relationship.build({:comments, comments}, context)
     assert [_ri1, _ri2, _ri3] = rel.data
   end
@@ -116,7 +119,8 @@ defmodule JaSerializer.Builder.RelationshipTest do
       data: [1,2,3],
       identifiers: :always
     }
-    context = %{conn: %{}, opts: [include: [author: []]]}
+
+    context = %{conn: %{}, opts: %{include: [author: []]}}
     rel = Relationship.build({:comments, comments}, context)
     assert [_ri1, _ri2, _ri3] = rel.data
   end
@@ -126,7 +130,8 @@ defmodule JaSerializer.Builder.RelationshipTest do
       serializer: CommentSerializer,
       identifiers: :when_included
     }
-    context = %{conn: %{}, opts: [include: [:author]]}
+
+    context = %{conn: %{}, opts: %{include: [:author]}}
     rel = Relationship.build({:comments, comments}, context)
     assert is_nil(rel.data)
   end
@@ -136,7 +141,8 @@ defmodule JaSerializer.Builder.RelationshipTest do
       serializer: CommentSerializer,
       identifiers: :when_included
     }
-    context = %{conn: %{}, opts: []}
+
+    context = %{conn: %{}, opts: %{}}
     rel = Relationship.build({:comments, comments}, context)
     assert rel.data == nil
   end

--- a/test/ja_serializer/builder/resource_object_test.exs
+++ b/test/ja_serializer/builder/resource_object_test.exs
@@ -11,7 +11,7 @@ defmodule JaSerializer.Builder.ResourceObjectTest do
   test "single resource object built correctly" do
     a1 = %TestModel.Article{id: "a1", title: "a1", body: "a1"}
 
-    context = %{data: a1, conn: %{}, serializer: ArticleSerializer, opts: []}
+    context = %{data: a1, conn: %{}, serializer: ArticleSerializer, opts: %{}}
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
 
     assert %{id: "a1", attributes: attributes} = primary_resource
@@ -30,7 +30,13 @@ defmodule JaSerializer.Builder.ResourceObjectTest do
     a1 = %TestModel.Article{id: "a1", title: "a1", body: "a1"}
     fields = %{"articles" => "title"}
 
-    context = %{data: a1, conn: %{}, serializer: ArticleSerializer, opts: [fields: fields]}
+    context = %{
+      data: a1,
+      conn: %{},
+      serializer: ArticleSerializer,
+      opts: %{fields: fields}
+    }
+
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
 
     assert %{id: "a1", attributes: attributes} = primary_resource

--- a/test/ja_serializer/builder/resource_object_test.exs
+++ b/test/ja_serializer/builder/resource_object_test.exs
@@ -15,7 +15,7 @@ defmodule JaSerializer.Builder.ResourceObjectTest do
     primary_resource = JaSerializer.Builder.ResourceObject.build(context)
 
     assert %{id: "a1", attributes: attributes} = primary_resource
-    assert [_,_] = attributes
+    assert [_, _] = attributes
 
     # Formatted
     json = JaSerializer.format(ArticleSerializer, a1)

--- a/test/ja_serializer/builder/scrivener_links_test.exs
+++ b/test/ja_serializer/builder/scrivener_links_test.exs
@@ -8,12 +8,14 @@ defmodule JaSerializer.Builder.ScrivenerLinksTest do
       page_size: 20,
       total_pages: 30
     }
+
     context = %{
       data: page,
       conn: %Plug.Conn{query_params: %{}},
       serializer: PersonSerializer,
       opts: []
     }
+
     links = ScrivenerLinks.build(context)
     assert URI.decode(links[:first]) == "?page[number]=1&page[size]=20"
     assert URI.decode(links[:prev]) == "?page[number]=9&page[size]=20"

--- a/test/ja_serializer/builder/top_level_test.exs
+++ b/test/ja_serializer/builder/top_level_test.exs
@@ -10,27 +10,30 @@ defmodule JaSerializer.Builder.TopLevelTest do
     end
 
     def preload(data, _conn, _opts) do
-      Enum.map(data, &(%{&1 | last_name: "preloaded"}))
+      Enum.map(data, &%{&1 | last_name: "preloaded"})
     end
   end
 
   test "pagination with scrivener" do
     p1 = %TestModel.Person{id: "p1", first_name: "p1"}
+
     page = %Scrivener.Page{
       entries: [p1],
       page_number: 10,
       page_size: 20,
       total_pages: 30
     }
+
     context = %{
       data: page,
       conn: %Plug.Conn{query_params: %{}},
       serializer: PersonSerializer,
       opts: %{}
     }
+
     results = JaSerializer.Builder.TopLevel.build(context)
     [data] = results.data
-    links = Enum.map(results.links, &(&1.type)) |> Enum.sort
+    links = Enum.map(results.links, & &1.type) |> Enum.sort()
     assert data.id == "p1"
     assert :first in links
     assert :prev in links
@@ -41,24 +44,28 @@ defmodule JaSerializer.Builder.TopLevelTest do
 
   test "top level meta support" do
     p1 = %TestModel.Person{id: "p1", first_name: "p1"}
+
     context = %{
       data: p1,
       conn: %Plug.Conn{query_params: %{}},
       serializer: PersonSerializer,
       opts: %{meta: %{author: "Dohn Joe"}}
     }
+
     assert %{meta: meta} = JaSerializer.Builder.TopLevel.build(context)
     assert meta == %{author: "Dohn Joe"}
   end
 
   test "preload hook is called when building individual records" do
     p1 = %TestModel.Person{id: "p1", first_name: "p1"}
+
     context = %{
       data: p1,
       conn: %Plug.Conn{query_params: %{}},
       serializer: PersonSerializer,
       opts: %{}
     }
+
     assert %{data: data} = JaSerializer.Builder.TopLevel.build(context)
     assert data.data.last_name == "preloaded"
   end
@@ -66,12 +73,14 @@ defmodule JaSerializer.Builder.TopLevelTest do
   test "preload hook is called when building multiple records" do
     p1 = %TestModel.Person{id: "p1", first_name: "p1"}
     p2 = %TestModel.Person{id: "p2", first_name: "p2"}
+
     context = %{
       data: [p1, p2],
       conn: %Plug.Conn{query_params: %{}},
       serializer: PersonSerializer,
       opts: %{}
     }
+
     assert %{data: [b1, b2]} = JaSerializer.Builder.TopLevel.build(context)
     assert b1.data.last_name == "preloaded"
     assert b2.data.last_name == "preloaded"

--- a/test/ja_serializer/content_type_negotiation_test.exs
+++ b/test/ja_serializer/content_type_negotiation_test.exs
@@ -4,8 +4,8 @@ defmodule JaSerializer.ContentTypeNegotiationTest do
 
   defmodule ExamplePlug do
     use Plug.Builder
-    plug JaSerializer.ContentTypeNegotiation
-    plug :return
+    plug(JaSerializer.ContentTypeNegotiation)
+    plug(:return)
 
     def return(conn, _opts) do
       send_resp(conn, 200, "success")
@@ -16,66 +16,82 @@ defmodule JaSerializer.ContentTypeNegotiationTest do
   @invalid "application/vnd.api+json; charset=utf-8"
 
   test "Passes proper content-type and accept headers through" do
-    conn = Plug.Test.conn("POST", "/", %{})
-            |> put_req_header("content-type", @valid)
-            |> put_req_header("accept", @valid)
+    conn =
+      Plug.Test.conn("POST", "/", %{})
+      |> put_req_header("content-type", @valid)
+      |> put_req_header("accept", @valid)
+
     result = ExamplePlug.call(conn, [])
     assert result.status == 200
     assert result.resp_body == "success"
   end
 
   test "Passes proper content-type and missing accept headers through" do
-    conn = Plug.Test.conn("POST", "/", %{})
-            |> put_req_header("content-type", @valid)
+    conn =
+      Plug.Test.conn("POST", "/", %{})
+      |> put_req_header("content-type", @valid)
+
     result = ExamplePlug.call(conn, [])
     assert result.status == 200
     assert result.resp_body == "success"
   end
 
   test "Passes proper content-type and */* accept headers through" do
-    conn = Plug.Test.conn("POST", "/", %{})
-            |> put_req_header("content-type", @valid)
-            |> put_req_header("accept", "*/*")
+    conn =
+      Plug.Test.conn("POST", "/", %{})
+      |> put_req_header("content-type", @valid)
+      |> put_req_header("accept", "*/*")
+
     result = ExamplePlug.call(conn, [])
     assert result.status == 200
     assert result.resp_body == "success"
   end
 
   test "Passes proper content-type and application/* accept headers through" do
-    conn = Plug.Test.conn("POST", "/", %{})
-            |> put_req_header("content-type", @valid)
-            |> put_req_header("accept", "application/*")
+    conn =
+      Plug.Test.conn("POST", "/", %{})
+      |> put_req_header("content-type", @valid)
+      |> put_req_header("accept", "application/*")
+
     result = ExamplePlug.call(conn, [])
     assert result.status == 200
     assert result.resp_body == "success"
   end
 
   test "Passes no content-type and valid accept header through on DELETE" do
-    conn = Plug.Test.conn("DELETE", "/", %{})
-            |> put_req_header("accept", @valid)
+    conn =
+      Plug.Test.conn("DELETE", "/", %{})
+      |> put_req_header("accept", @valid)
+
     result = ExamplePlug.call(conn, [])
     assert result.status == 200
     assert result.resp_body == "success"
   end
 
   test "Returns 415 Unsupported Media Type if any media type params" do
-    conn = Plug.Test.conn("POST", "/", %{})
-            |> put_req_header("content-type", @invalid)
-            |> put_req_header("accept", @valid)
+    conn =
+      Plug.Test.conn("POST", "/", %{})
+      |> put_req_header("content-type", @invalid)
+      |> put_req_header("accept", @valid)
+
     result = ExamplePlug.call(conn, [])
     assert result.status == 415
   end
 
   test "Returns 406 Not Acceptable if all media type params" do
-    conn = Plug.Test.conn("GET", "/", %{})
-            |> put_req_header("accept", @invalid)
+    conn =
+      Plug.Test.conn("GET", "/", %{})
+      |> put_req_header("accept", @invalid)
+
     result = ExamplePlug.call(conn, [])
     assert result.status == 406
   end
 
   test "Sets content type when returning" do
-    conn = Plug.Test.conn("GET", "/", %{})
-            |> put_req_header("accept", @valid)
+    conn =
+      Plug.Test.conn("GET", "/", %{})
+      |> put_req_header("accept", @valid)
+
     result = ExamplePlug.call(conn, [])
     assert [@valid] = get_resp_header(result, "content-type")
   end

--- a/test/ja_serializer/dynamic_type_test.exs
+++ b/test/ja_serializer/dynamic_type_test.exs
@@ -3,15 +3,17 @@ defmodule JaSerializer.DynamicTypeTest do
 
   @wilbur %{id: 1, name: "Wilbur", type: "pig"}
   @charlotte %{id: 1, name: "Charlotte", type: "spider"}
-  @farm %{ id: 1,
-           name: "Green Acres",
-           animals: [@wilbur, @charlotte],
-           special_animal: @wilbur }
+  @farm %{
+    id: 1,
+    name: "Green Acres",
+    animals: [@wilbur, @charlotte],
+    special_animal: @wilbur
+  }
 
   defmodule AnimalSerializer do
     use JaSerializer
     attributes [:name]
-    def type, do: fn(animal, _conn) -> animal.type end
+    def type, do: fn animal, _conn -> animal.type end
   end
 
   defmodule FarmSerializer do
@@ -28,18 +30,23 @@ defmodule JaSerializer.DynamicTypeTest do
 
   test "works for multiple items" do
     animals = JaSerializer.format(AnimalSerializer, [@wilbur, @charlotte])
-    assert animals["data"] |> Enum.map(&(&1["type"])) == ~w(pig spider)
+    assert animals["data"] |> Enum.map(& &1["type"]) == ~w(pig spider)
   end
 
   test "works with 'has_many' relationship data" do
     farm = JaSerializer.format(FarmSerializer, @farm)
-    animals = farm["data"]["relationships"]["animals"]["data"] |> Enum.map(&(&1["type"]))
+
+    animals =
+      farm["data"]["relationships"]["animals"]["data"] |> Enum.map(& &1["type"])
+
     assert "pig" in animals
     assert "spider" in animals
   end
 
   test "works with 'has_one' relationship data" do
     farm = JaSerializer.format(FarmSerializer, @farm)
-    assert farm["data"]["relationships"]["special-animal"]["data"]["type"] == "pig"
+
+    assert farm["data"]["relationships"]["special-animal"]["data"]["type"] ==
+             "pig"
   end
 end

--- a/test/ja_serializer/ecto_error_serializer_test.exs
+++ b/test/ja_serializer/ecto_error_serializer_test.exs
@@ -15,9 +15,10 @@ defmodule JaSerializer.EctoErrorSerializerTest do
       "jsonapi" => %{"version" => "1.0"}
     }
 
-    assert expected == EctoErrorSerializer.format(
-      Ecto.Changeset.add_error(%Ecto.Changeset{}, :title, "is invalid")
-    )
+    assert expected ==
+             EctoErrorSerializer.format(
+               Ecto.Changeset.add_error(%Ecto.Changeset{}, :title, "is invalid")
+             )
   end
 
   test "Will correctly format a changeset with a count error" do
@@ -32,14 +33,15 @@ defmodule JaSerializer.EctoErrorSerializerTest do
       "jsonapi" => %{"version" => "1.0"}
     }
 
-    assert expected == EctoErrorSerializer.format(
-      Ecto.Changeset.add_error(
-        %Ecto.Changeset{},
-        :monies,
-        "must be more than %{count}",
-        [count: 10]
-      )
-    )
+    assert expected ==
+             EctoErrorSerializer.format(
+               Ecto.Changeset.add_error(
+                 %Ecto.Changeset{},
+                 :monies,
+                 "must be more than %{count}",
+                 count: 10
+               )
+             )
   end
 
   test "Will correctly format a changeset with multiple errors on one attribute" do
@@ -59,9 +61,10 @@ defmodule JaSerializer.EctoErrorSerializerTest do
       "jsonapi" => %{"version" => "1.0"}
     }
 
-    changeset = %Ecto.Changeset{}
-    |> Ecto.Changeset.add_error(:title, "is invalid")
-    |> Ecto.Changeset.add_error(:title, "shouldn't be blank")
+    changeset =
+      %Ecto.Changeset{}
+      |> Ecto.Changeset.add_error(:title, "is invalid")
+      |> Ecto.Changeset.add_error(:title, "shouldn't be blank")
 
     assert expected == EctoErrorSerializer.format(changeset)
   end
@@ -83,10 +86,22 @@ defmodule JaSerializer.EctoErrorSerializerTest do
       "jsonapi" => %{"version" => "1.0"}
     }
 
-    assert expected == EctoErrorSerializer.format(
-      Ecto.Changeset.add_error(%Ecto.Changeset{}, :title, "is invalid"), %{},
-      opts: [id: "1", status: "422", code: "1000", links: %{self: "http://localhost"}, meta: %{author: "Johnny"}]
-    )
+    assert expected ==
+             EctoErrorSerializer.format(
+               Ecto.Changeset.add_error(
+                 %Ecto.Changeset{},
+                 :title,
+                 "is invalid"
+               ),
+               %{},
+               opts: [
+                 id: "1",
+                 status: "422",
+                 code: "1000",
+                 links: %{self: "http://localhost"},
+                 meta: %{author: "Johnny"}
+               ]
+             )
   end
 
   test "Will not consider type hash when formatting a changeset" do
@@ -101,8 +116,11 @@ defmodule JaSerializer.EctoErrorSerializerTest do
       "jsonapi" => %{"version" => "1.0"}
     }
 
-    assert expected == EctoErrorSerializer.format(
-      Ecto.Changeset.add_error(%Ecto.Changeset{}, :title, "is invalid", type: {:array, :integer})
-    )
+    assert expected ==
+             EctoErrorSerializer.format(
+               Ecto.Changeset.add_error(%Ecto.Changeset{}, :title, "is invalid",
+                 type: {:array, :integer}
+               )
+             )
   end
 end

--- a/test/ja_serializer/error_serializer_test.exs
+++ b/test/ja_serializer/error_serializer_test.exs
@@ -4,7 +4,11 @@ defmodule JaSerializer.ErrorSerializerTest do
   alias JaSerializer.ErrorSerializer
 
   test "formatting one error" do
-    expected = %{"errors" => [%{ title: "foo", detail: "bar"}], "jsonapi" => %{"version" => "1.0"}}
+    expected = %{
+      "errors" => [%{title: "foo", detail: "bar"}],
+      "jsonapi" => %{"version" => "1.0"}
+    }
+
     assert expected == ErrorSerializer.format(%{title: "foo", detail: "bar"})
   end
 
@@ -16,14 +20,20 @@ defmodule JaSerializer.ErrorSerializerTest do
       ],
       "jsonapi" => %{"version" => "1.0"}
     }
-    assert expected == ErrorSerializer.format([
-      %{title: "foo", detail: "baz"},
-      %{title: "fu", detail: "bar"}
-    ])
+
+    assert expected ==
+             ErrorSerializer.format([
+               %{title: "foo", detail: "baz"},
+               %{title: "fu", detail: "bar"}
+             ])
   end
 
   test "ignore invalid fields" do
-    expected = %{"errors" => [%{title: "foo"}], "jsonapi" => %{"version" => "1.0"}}
+    expected = %{
+      "errors" => [%{title: "foo"}],
+      "jsonapi" => %{"version" => "1.0"}
+    }
+
     assert expected == ErrorSerializer.format(%{title: "foo", name: "bar"})
   end
 end

--- a/test/ja_serializer/formatter/attribute_test.exs
+++ b/test/ja_serializer/formatter/attribute_test.exs
@@ -8,8 +8,8 @@ defmodule JaSerializer.Formatter.AttributeTest do
   end
 
   defmodule SimpleSerializer do
-    def type(_,_), do: "simple"
-    def attributes(data,_), do: data
+    def type(_, _), do: "simple"
+    def attributes(data, _), do: data
   end
 
   defimpl JaSerializer.Formatter, for: [Example, Map] do
@@ -18,17 +18,19 @@ defmodule JaSerializer.Formatter.AttributeTest do
   end
 
   test "allows overriding for struct formatting" do
-    assert {"example", "foobar"} == JaSerializer.Formatter.format(%@attr{
-      key: :example,
-      value:  %Example{foo: "foo", bar: "bar"}
-    })
+    assert {"example", "foobar"} ==
+             JaSerializer.Formatter.format(%@attr{
+               key: :example,
+               value: %Example{foo: "foo", bar: "bar"}
+             })
   end
 
   test "map formatter can be changed" do
-    results = JaSerializer.Formatter.format(%@attr{
-      key: :example,
-      value:  %{foo: "foo", bar: "bar"}
-    })
+    results =
+      JaSerializer.Formatter.format(%@attr{
+        key: :example,
+        value: %{foo: "foo", bar: "bar"}
+      })
 
     assert {"example", "foobar"} == results
   end
@@ -43,9 +45,9 @@ defmodule JaSerializer.Formatter.AttributeTest do
 
     result = @attr.build(context)
 
-    refute :key_1 in Enum.map(result, &(&1.key))
-    assert :key_2 in Enum.map(result, &(&1.key))
-    assert :key_3 in Enum.map(result, &(&1.key))
+    refute :key_1 in Enum.map(result, & &1.key)
+    assert :key_2 in Enum.map(result, & &1.key)
+    assert :key_3 in Enum.map(result, & &1.key)
   end
 
   test "the correct keys are are filtered when given a list" do
@@ -58,8 +60,8 @@ defmodule JaSerializer.Formatter.AttributeTest do
 
     result = @attr.build(context)
 
-    refute :key_1 in Enum.map(result, &(&1.key))
-    assert :key_2 in Enum.map(result, &(&1.key))
-    assert :key_3 in Enum.map(result, &(&1.key))
+    refute :key_1 in Enum.map(result, & &1.key)
+    assert :key_2 in Enum.map(result, & &1.key)
+    assert :key_3 in Enum.map(result, & &1.key)
   end
 end

--- a/test/ja_serializer/formatter/attribute_test.exs
+++ b/test/ja_serializer/formatter/attribute_test.exs
@@ -34,10 +34,12 @@ defmodule JaSerializer.Formatter.AttributeTest do
   end
 
   test "the correct keys are filtered out with build" do
-    context = %{data: %{key_1: 1, key_2: 2, key_3: 3},
-                serializer: SimpleSerializer,
-                conn: nil,
-                opts: [fields: %{"simple"=>"key_2,key_3"}]}
+    context = %{
+      data: %{key_1: 1, key_2: 2, key_3: 3},
+      serializer: SimpleSerializer,
+      conn: nil,
+      opts: %{fields: %{"simple" => "key_2,key_3"}}
+    }
 
     result = @attr.build(context)
 
@@ -47,10 +49,12 @@ defmodule JaSerializer.Formatter.AttributeTest do
   end
 
   test "the correct keys are are filtered when given a list" do
-    context = %{data: %{key_1: 1, key_2: 2, key_3: 3},
-                serializer: SimpleSerializer,
-                conn: nil,
-                opts: [fields: %{"simple"=>[:key_2, :key_3]}]}
+    context = %{
+      data: %{key_1: 1, key_2: 2, key_3: 3},
+      serializer: SimpleSerializer,
+      conn: nil,
+      opts: %{fields: %{"simple" => [:key_2, :key_3]}}
+    }
 
     result = @attr.build(context)
 

--- a/test/ja_serializer/formatter/utils_test.exs
+++ b/test/ja_serializer/formatter/utils_test.exs
@@ -9,11 +9,14 @@ defmodule JaSerializer.Formatter.UtilsTest do
 
   test "formatting keys - dasherize" do
     assert Utils.format_key(:blog_post) == "blog-post"
-    assert Utils.do_format_key("approved_comments", :dasherized) == "approved-comments"
+
+    assert Utils.do_format_key("approved_comments", :dasherized) ==
+             "approved-comments"
   end
 
   test "formatting keys - underscore" do
-    assert Utils.do_format_key("approved_comments", :underscored) == "approved_comments"
+    assert Utils.do_format_key("approved_comments", :underscored) ==
+             "approved_comments"
   end
 
   test "Will humanize a string" do
@@ -33,7 +36,9 @@ defmodule JaSerializer.Formatter.UtilsTest do
 
   test "formatting keys - custom" do
     custom = {:custom, JaSerializer.Formatter.UtilsTest, :smasherize, nil}
-    assert Utils.do_format_key("approved_comments", custom) == "approvedcomments"
+
+    assert Utils.do_format_key("approved_comments", custom) ==
+             "approvedcomments"
   end
 
   test "formatting type - dasherize - by default" do
@@ -43,15 +48,20 @@ defmodule JaSerializer.Formatter.UtilsTest do
 
   test "formatting type - dasherize" do
     assert Utils.format_type("BlogPost") == "blog-post"
-    assert Utils.do_format_type("ApprovedComments", :dasherized) == "approved-comments"
+
+    assert Utils.do_format_type("ApprovedComments", :dasherized) ==
+             "approved-comments"
   end
 
   test "formatting type - underscored" do
-    assert Utils.do_format_type("ApprovedComments", :underscored) == "approved_comments"
+    assert Utils.do_format_type("ApprovedComments", :underscored) ==
+             "approved_comments"
   end
 
   test "formatting type - custom" do
     custom = {:custom, JaSerializer.Formatter.UtilsTest, :smasherize, nil}
-    assert Utils.do_format_type("approved_comments", custom) == "approvedcomments"
+
+    assert Utils.do_format_type("approved_comments", custom) ==
+             "approvedcomments"
   end
 end

--- a/test/ja_serializer/json_api_spec/compound_document_test.exs
+++ b/test/ja_serializer/json_api_spec/compound_document_test.exs
@@ -93,18 +93,22 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
     def type, do: "articles"
     location "/articles/:id"
     attributes [:title]
+
     has_many :comments,
       link: "/articles/:id/comments",
       serializer: CommentSerializer,
       include: true
+
     has_one :author,
       link: "/articles/:id/author",
       serializer: PersonSerializer,
       include: true
+
     has_many :likes,
       link: "/articles/:id/likes",
       serializer: LikeSerializer,
       include: true
+
     has_one :excerpt,
       link: "/articles/:id/excerpt",
       serializer: ExcerptSerializer,
@@ -121,6 +125,7 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
     def type, do: "articles"
     def links(_data, _conn), do: [self: "/articles/:id"]
     def attributes(article, _conn), do: Map.take(article, [:title])
+
     def relationships(article, _conn) do
       %{
         comments: %HasMany{
@@ -201,7 +206,7 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
       title: "JSON API paints my bikeshed!",
       author: author,
       comments: [c1, c2],
-      likes: [],
+      likes: []
     }
 
     page = %Scrivener.Page{
@@ -220,11 +225,12 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
   end
 
   test "it serializes properly via the DSL", %{page: page, conn: conn} do
-    hashset = & Enum.into(&1, MapSet.new)
+    hashset = &Enum.into(&1, MapSet.new())
 
-    results = JaSerializer.format(ArticleSerializer, page, conn, [])
-              |> Poison.encode!
-              |> Poison.decode!(keys: :atoms)
+    results =
+      JaSerializer.format(ArticleSerializer, page, conn, [])
+      |> Poison.encode!()
+      |> Poison.decode!(keys: :atoms)
 
     expected = Poison.decode!(@expected, keys: :atoms)
 
@@ -236,11 +242,12 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
   end
 
   test "it serializes properly via the behaviour", %{page: page, conn: conn} do
-    hashset = & Enum.into(&1, MapSet.new)
+    hashset = &Enum.into(&1, MapSet.new())
 
-    results = JaSerializer.format(PostSerializer, page, conn, [])
-              |> Poison.encode!
-              |> Poison.decode!(keys: :atoms)
+    results =
+      JaSerializer.format(PostSerializer, page, conn, [])
+      |> Poison.encode!()
+      |> Poison.decode!(keys: :atoms)
 
     expected = Poison.decode!(@expected, keys: :atoms)
 
@@ -251,10 +258,12 @@ defmodule JaSerializer.JsonApiSpec.CompoundDocumentTest do
     assert Map.delete(results, :included) == Map.delete(expected, :included)
   end
 
-  test "it does not return any relationships when relationships opt is false", %{page: page, conn: conn} do
-    results = JaSerializer.format(PostSerializer, page, conn, relationships: false)
-              |> Poison.encode!
-              |> Poison.decode!(keys: :atoms)
+  test "it does not return any relationships when relationships opt is false",
+       %{page: page, conn: conn} do
+    results =
+      JaSerializer.format(PostSerializer, page, conn, relationships: false)
+      |> Poison.encode!()
+      |> Poison.decode!(keys: :atoms)
 
     refute results[:included]
     refute results[:data][:relationships]

--- a/test/ja_serializer/json_api_spec/resource_object_test.exs
+++ b/test/ja_serializer/json_api_spec/resource_object_test.exs
@@ -42,13 +42,17 @@ defmodule JaSerializer.JsonApiSpec.ResourceObjectTest do
 
     def type, do: "articles"
     attributes [:title]
+
     has_one :author,
       link: "/articles/:id/author",
       type: "people"
+
     has_many :comments,
       link: "/articles/:id/comments"
+
     has_many :likes,
       type: "like"
+
     has_one :excerpt,
       type: "excerpt"
 
@@ -60,12 +64,17 @@ defmodule JaSerializer.JsonApiSpec.ResourceObjectTest do
     def type, do: "articles"
     def meta(_article, _conn), do: %{search_match: "Omakase"}
     def attributes(post, _conn), do: %{title: post.title}
+
     def relationships(post, _conn) do
       %{
-        author:   %HasOne{links: [related: "/articles/:id/author"], type: "people", data: post.author},
+        author: %HasOne{
+          links: [related: "/articles/:id/author"],
+          type: "people",
+          data: post.author
+        },
         comments: %HasMany{links: [related: "/articles/:id/comments"]},
-        likes:    %HasMany{type: "like", data: post.likes},
-        excerpt:  %HasOne{type: "excerpt"}
+        likes: %HasMany{type: "like", data: post.likes},
+        excerpt: %HasOne{type: "excerpt"}
       }
     end
   end
@@ -85,21 +94,26 @@ defmodule JaSerializer.JsonApiSpec.ResourceObjectTest do
       comments: [],
       likes: []
     }
+
     {:ok, author: author, article: article}
   end
 
   test "it serializes properly using DSL", %{article: article} do
-    results = JaSerializer.format(ArticleSerializer, article, %{}, meta: %{copyright: 2015})
-              |> Poison.encode!
-              |> Poison.decode!(keys: :atoms)
+    results =
+      JaSerializer.format(ArticleSerializer, article, %{},
+        meta: %{copyright: 2015}
+      )
+      |> Poison.encode!()
+      |> Poison.decode!(keys: :atoms)
 
     assert results == Poison.decode!(@expected, keys: :atoms)
   end
 
   test "it serializes properly using behaviour", %{article: article} do
-    results = JaSerializer.format(PostSerializer, article, %{}, meta: %{copyright: 2015})
-              |> Poison.encode!
-              |> Poison.decode!(keys: :atoms)
+    results =
+      JaSerializer.format(PostSerializer, article, %{}, meta: %{copyright: 2015})
+      |> Poison.encode!()
+      |> Poison.decode!(keys: :atoms)
 
     assert results == Poison.decode!(@expected, keys: :atoms)
   end

--- a/test/ja_serializer/param_parser_test.exs
+++ b/test/ja_serializer/param_parser_test.exs
@@ -4,9 +4,10 @@ defmodule JaSerializer.ParamParserTest do
   import JaSerializer.ParamParser, only: [parse: 1]
 
   setup do
-    on_exit fn ->
+    on_exit(fn ->
       Application.delete_env(:ja_serializer, :key_format)
-    end
+    end)
+
     :ok
   end
 
@@ -14,7 +15,7 @@ defmodule JaSerializer.ParamParserTest do
     params = %{
       "data" => %{
         "type" => "example",
-        "id"   => "one",
+        "id" => "one",
         "attributes" => %{
           "some-nonsense" => true,
           "foo-bar" => "unaffected-values",
@@ -24,14 +25,14 @@ defmodule JaSerializer.ParamParserTest do
         },
         "relationships" => %{
           "my-model" => %{
-            "links" => %{ "related" => "/api/my_model/1" },
-            "data" => %{ "type" => "my_model", "id" => "1" }
+            "links" => %{"related" => "/api/my_model/1"},
+            "data" => %{"type" => "my_model", "id" => "1"}
           },
           "plural_models" => %{
-            "links" => %{ "related" => "/api/examples/one/plural_models" },
+            "links" => %{"related" => "/api/examples/one/plural_models"},
             "data" => [
-              %{ "type" => "plural_model", "id" => "1" },
-              %{ "type" => "plural_model", "id" => "2" }
+              %{"type" => "plural_model", "id" => "1"},
+              %{"type" => "plural_model", "id" => "2"}
             ]
           }
         }
@@ -41,7 +42,7 @@ defmodule JaSerializer.ParamParserTest do
     params_with_custom_keys = %{
       "data" => %{
         "type" => "example",
-        "id"   => "one",
+        "id" => "one",
         "attributes" => %{
           "someNonsense" => true,
           "fooBar" => "unaffected-values",
@@ -51,14 +52,14 @@ defmodule JaSerializer.ParamParserTest do
         },
         "relationships" => %{
           "myModel" => %{
-            "links" => %{ "related" => "/api/my_model/1" },
-            "data" => %{ "type" => "my_model", "id" => "1" }
+            "links" => %{"related" => "/api/my_model/1"},
+            "data" => %{"type" => "my_model", "id" => "1"}
           },
           "pluralModels" => %{
-            "links" => %{ "related" => "/api/examples/one/plural_models" },
+            "links" => %{"related" => "/api/examples/one/plural_models"},
             "data" => [
-              %{ "type" => "plural_model", "id" => "1" },
-              %{ "type" => "plural_model", "id" => "2" }
+              %{"type" => "plural_model", "id" => "1"},
+              %{"type" => "plural_model", "id" => "2"}
             ]
           }
         }
@@ -68,7 +69,7 @@ defmodule JaSerializer.ParamParserTest do
     expected = %{
       "data" => %{
         "type" => "example",
-        "id"   => "one",
+        "id" => "one",
         "attributes" => %{
           "some_nonsense" => true,
           "foo_bar" => "unaffected-values",
@@ -78,14 +79,14 @@ defmodule JaSerializer.ParamParserTest do
         },
         "relationships" => %{
           "my_model" => %{
-            "links" => %{ "related" => "/api/my_model/1" },
-            "data" => %{ "type" => "my_model", "id" => "1" }
+            "links" => %{"related" => "/api/my_model/1"},
+            "data" => %{"type" => "my_model", "id" => "1"}
           },
           "plural_models" => %{
-            "links" => %{ "related" => "/api/examples/one/plural_models" },
+            "links" => %{"related" => "/api/examples/one/plural_models"},
             "data" => [
-              %{ "type" => "plural_model", "id" => "1" },
-              %{ "type" => "plural_model", "id" => "2" }
+              %{"type" => "plural_model", "id" => "1"},
+              %{"type" => "plural_model", "id" => "2"}
             ]
           }
         }
@@ -97,14 +98,19 @@ defmodule JaSerializer.ParamParserTest do
     Application.put_env(:ja_serializer, :key_format, :underscored)
     assert parse(params) == params
 
-    Application.put_env(:ja_serializer, :key_format, {:custom, Macro, nil, :underscore})
+    Application.put_env(
+      :ja_serializer,
+      :key_format,
+      {:custom, Macro, nil, :underscore}
+    )
+
     assert parse(params_with_custom_keys) == expected
   end
 
   test "converts query param key names" do
     params = %{
       "page" => %{
-        "page-size" => "",
+        "page-size" => ""
       },
       "filter" => %{
         "foo-attr" => "val"
@@ -113,7 +119,7 @@ defmodule JaSerializer.ParamParserTest do
 
     params_with_custom_keys = %{
       "page" => %{
-        "pageSize" => "",
+        "pageSize" => ""
       },
       "filter" => %{
         "fooAttr" => "val"
@@ -122,7 +128,7 @@ defmodule JaSerializer.ParamParserTest do
 
     expected = %{
       "page" => %{
-        "page_size" => "",
+        "page_size" => ""
       },
       "filter" => %{
         "foo_attr" => "val"
@@ -134,7 +140,12 @@ defmodule JaSerializer.ParamParserTest do
     Application.put_env(:ja_serializer, :key_format, :underscored)
     assert parse(params) == params
 
-    Application.put_env(:ja_serializer, :key_format, {:custom, Macro, nil, :underscore})
+    Application.put_env(
+      :ja_serializer,
+      :key_format,
+      {:custom, Macro, nil, :underscore}
+    )
+
     assert parse(params_with_custom_keys) == expected
   end
 
@@ -142,9 +153,11 @@ defmodule JaSerializer.ParamParserTest do
     params = %{
       "foo-key" => %Plug.Upload{filename: "foo.bar"}
     }
+
     expected = %{
       "foo_key" => %Plug.Upload{filename: "foo.bar"}
     }
+
     assert parse(params) == expected
   end
 end

--- a/test/ja_serializer/params_test.exs
+++ b/test/ja_serializer/params_test.exs
@@ -4,27 +4,34 @@ defmodule JaSerializer.ParamsTest do
   import JaSerializer.Params, only: [to_attributes: 1]
 
   test "no relationships" do
-    input = %{"data" => %{
-      "id" => 1,
-      "type" => "person",
-      "attributes" => %{"first" => "Jane", "last" => "Doe"}
-    }}
+    input = %{
+      "data" => %{
+        "id" => 1,
+        "type" => "person",
+        "attributes" => %{"first" => "Jane", "last" => "Doe"}
+      }
+    }
+
     output = %{
       "id" => 1,
       "first" => "Jane",
       "last" => "Doe",
       "type" => "person"
     }
+
     assert to_attributes(input) == output
   end
 
   test "singular relationship" do
-    input = %{"data" => %{
-      "id" => 1,
-      "type" => "person",
-      "attributes" => %{"first" => "Jane", "last" => "Doe", "type" => "anon"},
-      "relationships" => %{"user" => %{"data" => %{"id" => 1}}}
-    }}
+    input = %{
+      "data" => %{
+        "id" => 1,
+        "type" => "person",
+        "attributes" => %{"first" => "Jane", "last" => "Doe", "type" => "anon"},
+        "relationships" => %{"user" => %{"data" => %{"id" => 1}}}
+      }
+    }
+
     output = %{
       "id" => 1,
       "first" => "Jane",
@@ -32,16 +39,20 @@ defmodule JaSerializer.ParamsTest do
       "type" => "anon",
       "user_id" => 1
     }
+
     assert to_attributes(input) == output
   end
 
   test "nil relationship" do
-    input = %{"data" => %{
-      "id" => 1,
-      "type" => "person",
-      "attributes" => %{"first" => "Jane", "last" => "Doe", "type" => "anon"},
-      "relationships" => %{"user" => %{"data" => nil}}
-    }}
+    input = %{
+      "data" => %{
+        "id" => 1,
+        "type" => "person",
+        "attributes" => %{"first" => "Jane", "last" => "Doe", "type" => "anon"},
+        "relationships" => %{"user" => %{"data" => nil}}
+      }
+    }
+
     output = %{
       "id" => 1,
       "first" => "Jane",
@@ -49,16 +60,22 @@ defmodule JaSerializer.ParamsTest do
       "type" => "anon",
       "user_id" => nil
     }
+
     assert to_attributes(input) == output
   end
 
   test "plural relationships" do
-    input = %{"data" => %{
-      "id" => 1,
-      "type" => "person",
-      "attributes" => %{"first" => "Jane", "last" => "Doe", "type" => "anon"},
-      "relationships" => %{"user" => %{"data" => [%{"id" => 1}, %{"id" => 2}]}}
-    }}
+    input = %{
+      "data" => %{
+        "id" => 1,
+        "type" => "person",
+        "attributes" => %{"first" => "Jane", "last" => "Doe", "type" => "anon"},
+        "relationships" => %{
+          "user" => %{"data" => [%{"id" => 1}, %{"id" => 2}]}
+        }
+      }
+    }
+
     output = %{
       "id" => 1,
       "first" => "Jane",
@@ -66,6 +83,7 @@ defmodule JaSerializer.ParamsTest do
       "type" => "anon",
       "user_ids" => [1, 2]
     }
+
     assert to_attributes(input) == output
   end
 end

--- a/test/ja_serializer/phoenix_view_test.exs
+++ b/test/ja_serializer/phoenix_view_test.exs
@@ -16,7 +16,7 @@ defmodule JaSerializer.PhoenixViewTest do
   end
 
   defmodule Page do
-    defstruct [page_number: 3, total_pages: 5, page_size: 10]
+    defstruct page_number: 3, total_pages: 5, page_size: 10
   end
 
   test "render conn, index.json-api, data: data", c do
@@ -42,24 +42,36 @@ defmodule JaSerializer.PhoenixViewTest do
   end
 
   test "render conn, index.json-api, model: model with custom pagination", c do
-    json = @view.render("index.json-api", conn: %{}, data: [c[:m1], c[:m2]],
-      opts: [page: [first: "/v1/posts/foo"]])
+    json =
+      @view.render("index.json-api",
+        conn: %{},
+        data: [c[:m1], c[:m2]],
+        opts: [page: [first: "/v1/posts/foo"]]
+      )
+
     assert [a1, _a2] = json["data"]
     assert Map.has_key?(a1, "id")
     assert Map.has_key?(a1, "attributes")
     assert Map.has_key?(json, "links")
   end
 
-  test "render conn, index.json-api, model: model with custom pagination using urls with ports", c do
-    json = @view.render("index.json-api", conn: %{}, data: [c[:m1], c[:m2]],
-      opts: [page: [first: "http://localhost:4000/v1/posts/foo"]])
+  test "render conn, index.json-api, model: model with custom pagination using urls with ports",
+       c do
+    json =
+      @view.render("index.json-api",
+        conn: %{},
+        data: [c[:m1], c[:m2]],
+        opts: [page: [first: "http://localhost:4000/v1/posts/foo"]]
+      )
+
     assert [a1, _a2] = json["data"]
     assert Map.has_key?(a1, "id")
     assert Map.has_key?(a1, "attributes")
     assert Map.has_key?(json, "links")
   end
 
-  test "render conn, index.json-api, model: model with scrivener pagination", c do
+  test "render conn, index.json-api, model: model with scrivener pagination",
+       c do
     model = %Scrivener.Page{entries: [c[:m1], c[:m2]], page_number: 1}
     conn = %Plug.Conn{query_params: %{}}
     json = @view.render("index.json-api", conn: conn, data: model)

--- a/test/ja_serializer/serializer_test.exs
+++ b/test/ja_serializer/serializer_test.exs
@@ -5,13 +5,13 @@ defmodule JaSerializer.SerializerTest do
     use JaSerializer
     attributes [:title]
     attributes [:body]
-    has_many :comments
+    has_many(:comments)
   end
 
   defmodule ArticleView do
     use JaSerializer
     attributes [:title, :body]
-    has_many :comments
+    has_many(:comments)
 
     def attributes(article, conn) do
       super(article, conn) |> Map.take([:title])
@@ -44,9 +44,9 @@ defmodule JaSerializer.SerializerTest do
     article = %TestModel.Article{title: "test", body: "test"}
 
     assert @serializer.attributes(article, %{}) == %{
-      title: "test",
-      body: "test"
-    }
+             title: "test",
+             body: "test"
+           }
 
     assert @view.attributes(article, %{}) == %{title: "test"}
     assert @custom.attributes(article, %{}) == %{body: "test"}
@@ -64,7 +64,7 @@ defmodule JaSerializer.SerializerTest do
     defmodule NewArticleSerializer do
       use JaSerializer
       attributes [:title, :body]
-      has_many :comments
+      has_many(:comments)
     end
 
     assert NewArticleSerializer.type() == "new-articles"

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,6 +1,5 @@
 ExUnit.start()
 
-
 defmodule TestModel.Person do
   defstruct [:id, :first_name, :last_name, :twitter, :publishing_agent]
 end


### PR DESCRIPTION
- Since `opts` is always a map, we don't need to use the indirection provided by the `Access` APIs
- When building `Included` items, we only need to create the full `ResourceObject` if we haven't seen the item
- run Travis against Elixir 1.9 and 1.10