### PR TITLE
fix: don't render empty relationships

### DIFF
--- a/lib/ja_serializer/builder/relationship.ex
+++ b/lib/ja_serializer/builder/relationship.ex
@@ -10,8 +10,12 @@ defmodule JaSerializer.Builder.Relationship do
         %{serializer: serializer, data: data, conn: conn, opts: opts} = context
       ) do
     case Map.get(opts, :relationships) do
-      false -> []
-      _ -> Enum.map(serializer.relationships(data, conn), &build(&1, context))
+      false ->
+        []
+
+      _ ->
+        Enum.map(serializer.relationships(data, conn), &build(&1, context))
+        |> Enum.filter(fn r -> not empty?(r) end)
     end
   end
 
@@ -22,6 +26,9 @@ defmodule JaSerializer.Builder.Relationship do
     |> add_links(definition, context)
     |> add_data(definition, context)
   end
+
+  defp empty?(%__MODULE__{data: nil, links: nil, meta: nil}), do: true
+  defp empty?(%__MODULE__{} = _relationship), do: false
 
   defp add_links(relation, definition, context) do
     definition.links

--- a/test/ja_serializer/builder/relationship_test.exs
+++ b/test/ja_serializer/builder/relationship_test.exs
@@ -23,6 +23,21 @@ defmodule JaSerializer.Builder.RelationshipTest do
     attributes [:body]
   end
 
+  defmodule CommentWithArticleSerializer do
+    use JaSerializer
+    def id(comment, _conn), do: comment.comment_id
+    def type, do: "comments"
+    location("/comments/:id")
+    attributes([:body])
+
+    has_one(
+      :article,
+      serializer: ArticleSerializer,
+      include: false,
+      identifiers: :when_included
+    )
+  end
+
   defmodule FooSerializer do
     use JaSerializer
 
@@ -153,6 +168,17 @@ defmodule JaSerializer.Builder.RelationshipTest do
     json =
       JaSerializer.format(FooSerializer, %{baz_id: 1, id: 1}, %{},
         relationships: false
+      )
+
+    refute Map.has_key?(json["data"], "relationships")
+  end
+
+  test "empty relationships are not included" do
+    json =
+      JaSerializer.format(
+        CommentWithArticleSerializer,
+        %{comment_id: 1, article: %{title: "title"}},
+        %{}
       )
 
     refute Map.has_key?(json["data"], "relationships")


### PR DESCRIPTION
Cherry-pick of upstream commit 9823ada7.

[Someone noticed](https://groups.google.com/g/massdotdevelopers/c/hXyux8ahL7Q) our `relationships` output in the V3 API wasn't spec-compliant — I found this was a bug in `ja_serializer` that was [fixed upstream](https://github.com/vt-elixir/ja_serializer/pull/311) after we made this fork. Since it's a simple enough change, I thought we could cherry-pick it. However I also made a TRC task for us to look into updating this fork in general.

This repo doesn't appear to have CI, but `mix test` passes locally on this branch. When I point `api` at this branch, its test suite passes as well, except for one case that uses `relationship == %{}` to assert the absence of a relationship.